### PR TITLE
Hotfix: TypeScript build error in CI

### DIFF
--- a/screensearch-ui/package-lock.json
+++ b/screensearch-ui/package-lock.json
@@ -22,6 +22,7 @@
         "zustand": "^5.0.1"
       },
       "devDependencies": {
+        "@types/node": "^25.0.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@typescript-eslint/eslint-plugin": "^8.15.0",
@@ -1462,6 +1463,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.1.tgz",
+      "integrity": "sha512-czWPzKIAXucn9PtsttxmumiQ9N0ok9FrBwgRWrwmVLlp86BrMExzvXRLFYRJ+Ex3g6yqj+KuaxfX1JTgV2lpfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -4758,6 +4769,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/screensearch-ui/package.json
+++ b/screensearch-ui/package.json
@@ -24,6 +24,7 @@
     "zustand": "^5.0.1"
   },
   "devDependencies": {
+    "@types/node": "^25.0.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@typescript-eslint/eslint-plugin": "^8.15.0",


### PR DESCRIPTION
Fixes the GitHub Actions build failure by adding missing @types/node dependency.

## Issue
GitHub Actions was failing with error: "Cannot find namespace 'NodeJS'"

## Fix
Added @types/node to screensearch-ui devDependencies

## Testing
- ✅ Builds successfully locally
- [ ] Will build successfully in GitHub Actions after merge

Fixes the failed release build for v0.2.0