### PR TITLE
Redesign frontend UI with brutalist/minimalist theme and dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0] - 2026-06-10
+
+### Changed
+- **Brutalist / Minimalist Paper UI Redesign**: Overhauled the entire React frontend to match the print-media brutalist design of `screensearch-website`.
+  - Replaced glassmorphism visual layout, translucent backdrops, radial gradients, glowing accents, and rounded corners with a flat, sharp, 90-degree corner design.
+  - Implemented dynamic light and dark theme modes using custom HSL theme tokens (`bg-paper`, `text-ink`, `border-rule`).
+  - Adopted newspaper-style typography: **Newsreader** (Serif) for headers and inputs, **Geist** (Sans) for UI copy, and **Geist Mono** (Monospace) for data metrics.
+  - Redesigned `Sidebar.tsx`, `Timeline.tsx`, `FrameCard.tsx`, `SearchBar.tsx`, `Dashboard.tsx`, `Intelligence.tsx`, `AiSettings.tsx`, `SettingsPanel.tsx`, and `GlassCard.tsx` base components to utilize flat paper backgrounds, solid rule borders, and physical hover transforms instead of glows.
+
+### Added
+- **Dynamic Dark Mode**: Built support directly into the HSL variables in `index.css` via the `.dark` class, toggled by the existing state mechanism in `useStore.ts` and `App.tsx`.
+
+---
+
 ## [0.4.32] - 2026-01-10
 
 ### Fixed
@@ -505,6 +519,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - React-based web interface
   - Privacy controls and application exclusions
 
+[0.5.0]: https://github.com/nicolasestrem/screensearch/compare/v0.4.32...v0.5.0
 [0.4.2]: https://github.com/nicolasestrem/screensearch/compare/v0.4.1...v0.4.2
 [0.4.1]: https://github.com/nicolasestrem/screensearch/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/nicolasestrem/screensearch/compare/v0.3.0...v0.4.0

--- a/README.md
+++ b/README.md
@@ -40,17 +40,17 @@
 ```
 
 <div align="center">
-  <h3>Light Theme — Premium Glassmorphism Design</h3>
+  <h3>Light Theme — Premium Brutalist / Minimalist Paper Design</h3>
   <img src="screenshots/dashboard-light.png" width="85%" alt="ScreenSearch Dashboard Light Theme - AI-powered Intel Dash with Daily Digest, Memory Status gauge, and Productivity Pulse chart">
-  <p><em>Modern glass-and-neon aesthetic with atmospheric radial gradients and fluid animations</em></p>
+  <p><em>Modern warm-paper aesthetic with sharp edges, solid rule lines, and elegant editorial typography</em></p>
 </div>
 
 <br/>
 
 <div align="center">
-  <h3>Dark Theme — Comfortable Night Mode</h3>
-  <img src="screenshots/dashboard-dark.png" width="85%" alt="ScreenSearch Dashboard Dark Theme - AI-First interface with glassmorphism cards and neon accents">
-  <p><em>Beautiful dark mode for late-night productivity tracking and focus sessions</em></p>
+  <h3>Dark Theme — Comfortable Dark Paper Theme</h3>
+  <img src="screenshots/dashboard-dark.png" width="85%" alt="ScreenSearch Dashboard Dark Theme - AI-First interface with flat dark paper card layouts and sharp styling">
+  <p><em>Beautiful dark paper variant for comfortable late-night focus sessions</em></p>
 </div>
 
 ---
@@ -61,7 +61,7 @@
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-- [*] **Sci-Fi Concept UI** — Premium "Glass & Neon" aesthetic with atmospheric depth and fluid animations
+- [*] **Editorial Brutalist UI** — Premium Minimalist "Paper & Ink" design system with light and dark mode, sharp edges, and elegant typography
 - [*] **AI-First Dashboard** — "Intel Dash" with Daily Digest, Memory Status gauge, and Productivity Pulse charts
 - [*] **Continuous Screen Capture** — Configurable intervals (2-5 seconds) with multi-monitor support
 - [*] **OCR Text Extraction** — Windows OCR API with bounding box coordinates and confidence scores
@@ -98,7 +98,7 @@
 
 ### [>] AI-First Dashboard — Your Intelligent Command Center
 
-The new **"Intel Dash"** puts AI-powered insights front and center with a beautiful glassmorphism design. See your day at a glance with auto-generated summaries, RAG indexing progress, and hourly activity charts.
+The new **"Intel Dash"** puts AI-powered insights front and center with a premium editorial paper layout. See your day at a glance with auto-generated summaries, RAG indexing progress, and hourly activity charts.
 
 **Dashboard Features:**
 - [*] **Daily Digest** — Auto-generated AI summaries of your screen activity
@@ -193,7 +193,7 @@ Fine-tune every aspect of ScreenSearch with comprehensive, intuitive settings pa
 
 ### [>] See It In Action — Dashboard Demo
 
-Watch the new Intel Dash come to life with smooth animations, real-time updates, and beautiful glassmorphism effects.
+Watch the new Intel Dash come to life with smooth animations, real-time updates, and a clean minimalist print interface.
 
 <div align="center">
   <img src="screenshots/demo-dashboard.gif" width="85%" alt="Animated demo of ScreenSearch dashboard with Daily Digest and charts">
@@ -267,7 +267,7 @@ npm run dev
 ```
 
 **Dashboard Features**:
-- [*] **Sci-Fi Visuals**: Atmospheric radial gradients, neon accents, and glassmorphism interface
+- [*] **Minimalist Editorial Visuals**: Warm paper and deep ink layouts with crisp rule borders, sharp corners, and editorial typography
 - [*] Timeline view of captured frames with real-time thumbnails
 - [*] Full-text search across all OCR content
 - [*] Intelligence tab with AI-powered report generation

--- a/docs/frontend-design-system.md
+++ b/docs/frontend-design-system.md
@@ -1,94 +1,80 @@
-# Frontend Design System: Sci-Fi Concept
+# Frontend Design System: Brutalist / Minimalist Paper
 
-**Version:** 1.0 (Visual Overhaul)
-**Theme:** "Dark Future" / "Cyberpunk Lite"
+**Version:** 2.0 (Brutalist Overhaul)
+**Theme:** "Brutalist / Minimalist Paper" (Light & Dark Variants)
 
 ## Core Philosophy
-The UI follows a **Sci-Fi / Cinematic** aesthetic characterized by:
-- **Atmospheric Depth:** Deep radial gradients and ambient "light blobs" (`.bg-blob`) to create 3D space.
-- **Glassmorphism:** Highly saturated, blurred surfaces that feel like physical glass (`backdrop-filter`).
-- **Neon Accents:** High-intensity cyan (`#00f2ff`) for active states, mimicking light emission.
-- **Precision:** Monospace typography (`font-mono`) for technical data to evoke a "system hud" feel.
+The UI follows a **Brutalist / Minimalist Paper** design system inspired by physical print media, editorial design, and clean interfaces, matching the design of `screensearch-website`:
+- **Paper & Ink Palette:** Flat warm cream/paper backgrounds and deep charcoal ink text in light mode, with a dedicated dark paper variant in dark mode.
+- **Zero Border-Radius:** Hard, sharp 90-degree edges on all elements (no rounded corners).
+- **Rule Borders:** Fine, solid 1px borders (`border-rule`) separating panels, cards, inputs, and components.
+- **Typographic Hierarchy:** Newspaper-style editorial headings using **Newsreader** (Serif) paired with clean geometric UI text using **Geist** (Sans-serif) and technical labels/ids in **Geist Mono** (Monospace).
+- **Interactive Shift:** Elements react to interactions with physical offsets (e.g. `hover:-translate-y-0.5 active:translate-y-0`) rather than soft diffuse shadows or light glows.
 
 ---
 
 ## Global Atmosphere
-Root styles defined in `index.css`.
+Root styles defined in `index.css` and registered in `tailwind.config.js`.
 
-### Background
-Replaces flat colors with a deep void gradient:
-```css
-background: radial-gradient(circle at 50% 0%, #1a2333 0%, #020617 100%);
-```
+### Color Tokens (HSL)
+We use tailwind color tokens mapping to raw HSL values defined dynamically under light and dark themes:
+- `bg-paper`: Primary paper background.
+- `bg-paper-2`: Secondary background layer for elevated widgets/inputs.
+- `text-ink`: Primary text color representing deep ink print.
+- `text-ink-muted`: Secondary text color for secondary content or helper descriptions.
+- `border-rule`: High-contrast fine border lines defining component boundaries.
+- `border-accent`: Distinctive highlight border for active/focused elements.
 
-### Ambient Lighting
-Injects colorful blurs behind content:
-- **Primary Blob:** Top-left cyan/blue.
-- **Secondary Blob:** Bottom-right violet/purple.
-- **Grid Pattern:** Subtle vector grid overlay for technical texture.
+#### Light Mode Colors
+- `--color-paper`: `40 23% 97%` (warm soft cream/paper)
+- `--color-paper-2`: `40 18% 94%` (slightly darker warm paper for components)
+- `--color-ink`: `240 6% 10%` (deep ink black)
+- `--color-ink-muted`: `240 4% 45%` (muted grey ink)
+- `--color-rule`: `240 6% 15%` (crisp, fine border rules)
+- `--color-accent`: `210 100% 50%` (ink blue accent highlight)
+
+#### Dark Mode (.dark) Colors
+- `--color-paper`: `240 6% 9%` (rich dark background)
+- `--color-paper-2`: `240 6% 13%` (elevated dark paper component layer)
+- `--color-ink`: `40 20% 95%` (warm light ink text)
+- `--color-ink-muted`: `40 10% 65%` (muted warm text)
+- `--color-rule`: `40 20% 25%` (subtle border rules)
+- `--color-accent`: `210 100% 65%` (bright blue highlight)
 
 ---
 
-## Utility Classes
-
-### 1. Glass Surfaces
-Use for containers, cards, and panels.
-
-| Class | Description |
-|-------|-------------|
-| `.glass-panel` | Base surface. High blur (20px), low opacity white tint (2%). |
-| `.glass-card` | Interactive surface. Adds hover glow and lift. |
-| `.glass-panel-cyan` | **High Attention**. Used for the Search Bubble. Cyan-tinted glass. |
+## Utility Classes & Containers
+The old glassmorphism panels have been completely replaced with paper-based components:
+- `bg-paper` / `bg-paper-2` for flat panels.
+- `border-rule` / `border-accent` for crisp borders.
+- `rounded-none` to guarantee sharp edges.
 
 **Example:**
 ```tsx
-<div className="glass-panel p-6 rounded-2xl">
+<div className="bg-paper border border-rule p-6 rounded-none">
   Content
 </div>
 ```
 
-### 2. High-Intensity Accents
-Use sparingly for "active" or "powered" items.
+---
 
-| Class | Description |
-|-------|-------------|
-| `.neon-text` | Cyan text with outer glow. `text-cyan-400 drop-shadow`. |
-| `.active-border` | "Beam" border effect. 1px cyan border + inset/outset shadows. |
-| `.glow-cyan-lg` | Large outer atmosphere glow. |
-
-**Example:**
-```tsx
-<button className={isActive ? "active-border neon-text" : "text-muted"}>
-  Dashboard
-</button>
-```
-
-### 3. Typography
-- **Primary Font:** Sans-serif (Inter) for UI labels and readability.
-- **Technical Font:** Monospaced (JetBrains Mono/Fira Code) for data points, IDs, and timestamps.
-
-**Usage:** Add `font-mono` to technical data.
-```tsx
-<span className="text-xs text-muted-foreground font-mono">
-  {latency_ms}ms
-</span>
-```
+## Typography
+- **Headings & Accents:** Serif (**Newsreader**) for a premium, newspaper editorial feel.
+- **Primary UI Text:** Sans-serif (**Geist**) for readability.
+- **Technical & Stats:** Monospaced (**Geist Mono**) for timestamp data, logs, and parameters.
 
 ---
 
 ## Components
 
-### Search Bubble (`SearchInvite.tsx`)
-A floating, detached modal that mimics a "thought bubble" or HUD element.
-- **Animation:** Spring physics (mass: 0.8, stiffness: 300).
-- **Style:** `glass-panel-cyan` with aggressive backdrop blur.
-- **Focus:** Input field scales slightly (`scale: 1.01`) on focus.
+### 1. Sidebar (`Sidebar.tsx`)
+- Sharp layout with zero border-radius.
+- Highlight border left edge indicates the active navigation state.
+- Sections headers styled using uppercase `font-mono` tracking wide.
 
-### Navigation Sidebar (`Sidebar.tsx`)
-- **Active State:** Uses `.active-border` and a CSS-based "glimmer" animation (`animate-[shimmer_2s_infinite]`).
-- **Icons:** Glow when active (`drop-shadow`).
+### 2. Search Modal (`SearchInvite.tsx`)
+- Detached search panel adopting the flat paper layout.
+- Search inputs use an italicized serif font for a premium look.
 
-### Dashboard Cards (`ProductivityPulse`, `MemoryStatus`)
-- **Header:** Icon + Title.
-- **Content:** Monospace data displays.
-- **Charts:** Uses SVG gradients matching the cyan theme (`#00f2ff` to `#00ff88`).
+### 3. GlassCard (`GlassCard.tsx`)
+- Fully redesigned to serve as the unified component container. It drops glassmorphism shadows and backdrop filters, replacing them with flat `bg-paper` background overlays, `rounded-none` corners, and solid `border-rule` boundaries.

--- a/screensearch-ui/FEATURES.md
+++ b/screensearch-ui/FEATURES.md
@@ -1,6 +1,6 @@
 # ScreenSearch UI - Features Documentation
 
-*Last updated: v0.3.0 - AI-First UI Redesign*
+*Last updated: v0.4.0 - Brutalist/Minimalist Paper UI Redesign*
 
 ---
 
@@ -11,7 +11,7 @@
 
 **Features**:
 - Global keyboard shortcut (Cmd/Ctrl+K) to open
-- Full-screen glassmorphism modal
+- Flat paper modal layout
 - Mode toggle between Search and Browse
 - Smart Answer integration with AI responses
 - Activity sources with app breakdowns
@@ -34,7 +34,7 @@
 - App-specific icons (Chrome, VSCode, Slack, etc.)
 - Time and app context for each source
 - Sparkle icon for AI indicator
-- Cyan accent glow effects
+- Minimalist highlight border effects
 
 ### Collapsible Sidebar
 **Location**: `src/components/Sidebar.tsx`
@@ -46,7 +46,7 @@
 - Search shortcut button with Cmd+K badge
 - Framer Motion animated width transitions
 - Toggle button with ChevronLeft/Right icons
-- Glassmorphism panel styling
+- Minimalist paper layout
 
 **User Interactions**:
 - Click toggle button to expand/collapse
@@ -70,7 +70,7 @@
 - AI-powered daily activity summaries
 - Session storage caching to reduce API calls
 - "Setup Required" badge when AI not configured
-- Glassmorphism card styling
+- Minimalist paper layout
 - CalendarDays icon indicator
 
 ### Memory Status Gauge
@@ -93,26 +93,20 @@
 - Responsive width with viewBox
 - Caption with last update time
 
-### Glassmorphism Design System
+### Brutalist & Minimalist Paper Design System
 **Location**: `src/index.css`, `tailwind.config.js`
 
 **Design Tokens**:
-- `--background`: Deep space (#0d1117)
-- `--primary`: Cyan (#00d4ff)
-- `--primary-light`: Glow cyan (#33e0ff)
-- `--accent-muted`: Subtle cyan (#265a66)
-- `--glass-bg`: Translucent dark
-- `--glass-border`: Cyan-tinted border
-- `--glass-glow`: Cyan glow effect
+- `bg-paper`: Primary paper background (warm cream in light mode, deep slate in dark mode)
+- `bg-paper-2`: Secondary background layer for elevated widgets/inputs
+- `text-ink`: Primary ink text color (ink black in light mode, warm light grey in dark mode)
+- `border-rule`: Structured fine border rule lines separating panels
+- `border-accent`: Distinctive highlight border for active elements
 
-**Utility Classes**:
-- `.glass-panel` - Base translucent container
-- `.glass-card` - Elevated with glow shadow
-- `.glass-panel-cyan` - Cyan border variant
-- `.glow-cyan` - Standard cyan glow
-- `.glow-cyan-lg` - Large cyan glow
-- `.text-glow-cyan` - Text with glow shadow
-- `.gradient-text-cyan` - Cyan-to-green gradient text
+**Typography**:
+- Serif (**Newsreader**): Newspaper-style editorial headings and search inputs
+- Sans (**Geist**): Primary UI typography
+- Mono (**Geist Mono**): Monospaced font for data points, tags, and timestamps
 
 ### Animation System
 **Location**: `src/lib/animations.ts`

--- a/screensearch-ui/FILE_INDEX.md
+++ b/screensearch-ui/FILE_INDEX.md
@@ -2,7 +2,7 @@
 
 Base Directory: `screensearch-ui/`
 
-*Last updated: v0.3.0 - AI-First UI Redesign*
+*Last updated: v0.4.0 - Brutalist/Minimalist Paper UI Redesign*
 
 ## Configuration Files (8)
 
@@ -10,7 +10,7 @@ Base Directory: `screensearch-ui/`
 2. `tsconfig.json`
 3. `tsconfig.node.json`
 4. `vite.config.ts`
-5. `tailwind.config.js` - Extended theme with glassmorphism, cyan accents
+5. `tailwind.config.js` - Brutalist design system with custom typography (Newsreader, Geist) and color tokens
 6. `postcss.config.js`
 7. `.eslintrc.cjs`
 8. `.gitignore`
@@ -60,21 +60,21 @@ Base Directory: `screensearch-ui/`
 31. `src/components/Sidebar.tsx` - Collapsible with framer-motion (v0.3.0)
 32. `src/components/Logo.tsx` - Updated with collapsed mode support (v0.3.0)
 
-## Search Components (v0.3.0)
+## Search Components
 
-33. `src/components/search/SearchInvite.tsx` - Cmd+K modal with glassmorphism
+33. `src/components/search/SearchInvite.tsx` - Cmd+K modal with minimalist paper styling
 34. `src/components/search/SmartAnswer.tsx` - AI answer with activity sources
 
-## Dashboard Components (v0.3.0)
+## Dashboard Components
 
 35. `src/components/dashboard/DailyDigestCard.tsx` - AI daily summaries
 36. `src/components/dashboard/MemoryStatusGauge.tsx` - RAG indexing status
-37. `src/components/dashboard/ProductivityPulse.tsx` - Cyan gradient chart
+37. `src/components/dashboard/ProductivityPulse.tsx` - Minimalist activity chart
 
-## UI Components (v0.3.0)
+## UI Components
 
-38. `src/components/ui/GlassCard.tsx` - Glassmorphism container with glow variants
-39. `src/components/ui/CircularGauge.tsx` - SVG radial progress with cyan gradient
+38. `src/components/ui/GlassCard.tsx` - Flat paper card with zero border-radius
+39. `src/components/ui/CircularGauge.tsx` - SVG radial progress chart
 40. `src/components/ui/ComingSoonCard.tsx` - Placeholder for upcoming features
 
 ## Pages
@@ -83,7 +83,7 @@ Base Directory: `screensearch-ui/`
 
 ## Styles (1)
 
-42. `src/index.css` - CSS design tokens, glassmorphism utilities, cyan accents
+42. `src/index.css` - CSS design tokens, paper/ink variables, custom fonts
 
 ## Documentation (8)
 
@@ -129,7 +129,7 @@ screensearch-ui/
 └── src/
     ├── main.tsx
     ├── App.tsx
-    ├── index.css              # Design tokens, glassmorphism utilities
+    ├── index.css              # Design tokens, paper/ink variables, typography
     ├── vite-env.d.ts
     │
     ├── api/

--- a/screensearch-ui/Frontend_IMPLEMENTATION_SUMMARY.md
+++ b/screensearch-ui/Frontend_IMPLEMENTATION_SUMMARY.md
@@ -1,8 +1,8 @@
 # Implementation Summary - ScreenSearch Frontend
 
-## Project Completion Status: COMPLETE (v0.3.0 - AI-First UI Redesign)
+## Project Completion Status: COMPLETE (v0.4.0 - Brutalist/Minimalist Paper UI Redesign)
 
-Complete React 18 frontend implementation for ScreenSearch with AI-First UI redesign featuring glassmorphism design system, search modal (Cmd+K), collapsible sidebar, and cyan accent theme.
+Complete React 18 frontend implementation for ScreenSearch with AI-First UI featuring the Brutalist / Minimalist Paper design system matching `screensearch-website`, light/dark mode support, search modal (Cmd+K), collapsible sidebar, and editorial layout.
 
 ## Files Created
 
@@ -66,6 +66,18 @@ Complete React 18 frontend implementation for ScreenSearch with AI-First UI rede
 37. `src/components/search/SearchInvite.tsx` - Search modal with Cmd+K trigger
 38. `src/components/search/SmartAnswer.tsx` - AI answer display with activity sources
 39. `src/lib/animations.ts` - Framer Motion animation variants
+
+### v0.4.0 Brutalist & Dark Mode Redesign (Updated Files)
+- `src/index.css` - Defined HSL paper, ink, rule border theme variables for light and dark modes
+- `tailwind.config.js` - Integrated custom fonts (Newsreader, Geist, Geist Mono) and brutalist CSS color tokens
+- `index.html` - Google Font link integration for Geist and Newsreader fonts
+- `src/components/ui/GlassCard.tsx` - Replaced glassmorphism layouts with unified flat paper boxes (`bg-paper`, `rounded-none`, `border-rule`)
+- `src/components/Sidebar.tsx` - Zero border-radius collapsible sidebar using solid borders and active state highlights
+- `src/components/SearchBar.tsx` - Minimalist search input with serif italic placeholder and zero border-radius
+- `src/components/FrameCard.tsx` - Flat card layout with sharp edges and translate hover effects
+- `src/components/Timeline.tsx` - Editorial timeline headers
+- `src/components/SettingsPanel.tsx` & `src/components/AiSettings.tsx` - Zero border-radius widgets and sharp inputs
+- `src/pages/Dashboard.tsx` & `src/pages/Intelligence.tsx` - Paper themes, serif styling, and removal of gradient backdrops
 
 ### v0.3.0 Updated Files
 - `src/index.css` - Cyan accent design tokens, glassmorphism utilities
@@ -164,17 +176,13 @@ Complete React 18 frontend implementation for ScreenSearch with AI-First UI rede
 - [x] Responsive design
 - [x] Smooth transitions
 
-### 9. AI-First UI Redesign (v0.3.0)
-- [x] Search Modal (Cmd+K) - Full-screen modal with glassmorphism
-- [x] Smart Answer Card - AI-generated answers with activity sources
-- [x] Collapsible Sidebar - Icon-only mode with framer-motion animations
-- [x] Cyan Accent Design System - Deep space background with cyan glow
-- [x] Glassmorphism Cards - Translucent cards with backdrop blur
-- [x] Circular Gauge - SVG radial progress with gradient glow
-- [x] Productivity Pulse Chart - Cyan gradient line chart
-- [x] Daily Digest Card - AI-powered daily summaries
-- [x] Animation System - Framer Motion variants for consistent animations
-- [x] ScreenSearch Intel branding - Updated dashboard title
+### 9. Brutalist & Minimalist Paper Design (v0.4.0)
+- [x] Paper & Ink Design - Warm cream paper background and dark ink text
+- [x] Dark Paper Mode - Built-in dark theme activated via `.dark` class
+- [x] Zero Border Radius - Razor sharp 90-degree corners on all elements
+- [x] Rule Border Systems - Solid 1px borders for structured editorial layout
+- [x] Editorial Typography - Newsreader (Serif) headings and Geist (Sans) copy
+- [x] Flat Components - Removed glassmorphism, drop shadows, glows, and gradients
 
 ### 7. Performance
 - [x] React Query caching

--- a/screensearch-ui/README.md
+++ b/screensearch-ui/README.md
@@ -1,6 +1,6 @@
 # ScreenSearch - Frontend UI
 
-Modern React-based web interface for ScreenSearch, a Windows screen capture and OCR tool. Features an AI-First UI redesign with glassmorphism design system, search modal (Cmd+K), and cyan accent theme.
+Modern React-based web interface for ScreenSearch, a Windows screen capture and OCR tool. Features an AI-First UI with a Brutalist / Minimalist Paper design system, light and dark modes, search modal (Cmd+K), and sharp editorial typography.
 
 ## Features
 
@@ -9,18 +9,18 @@ Modern React-based web interface for ScreenSearch, a Windows screen capture and 
 - **Timeline View**: Visual timeline of all captured screens with thumbnails
 - **Tag Management**: Organize captures with custom tags
 - **Settings Panel**: Configure capture intervals, privacy controls, and database management
-- **Dark Mode**: Full dark mode support with theme persistence
+- **Dark Mode**: Full dark mode support with theme persistence and custom HSL paper variables
 - **Responsive Design**: Desktop-optimized interface with fluid layouts
 - **Performance Optimized**: < 100ms interaction response time
 
-### AI-First UI Redesign (v0.3.0)
-- **Search Modal (Cmd+K)**: Full-screen search with glassmorphism, Smart Answers, and activity sources
-- **Collapsible Sidebar**: Icon-only mode with smooth framer-motion animations
-- **ScreenSearch Intel Dashboard**: AI-powered productivity insights with Daily Digest and Memory Status
-- **Cyan Accent Design System**: Deep space background with cyan glow effects
-- **Glassmorphism Cards**: Translucent cards with backdrop blur and glow variants
-- **Productivity Pulse Chart**: Custom SVG line chart with cyan gradient
-- **Circular Gauge**: SVG radial progress for Memory Status with glow effects
+### Brutalist & Minimalist Paper Design (v0.4.0)
+- **Paper & Ink Palette**: Custom warm cream/paper (`bg-paper`) backgrounds and deep ink (`text-ink`) text with a dark paper variant.
+- **Zero Border Radius**: Crisp 90-degree sharp corners across the entire application interface.
+- **Rule Borders**: Fine, solid 1px borders (`border-rule`) demarcating components and inputs.
+- **Editorial Typography**: Styled headers and search inputs using Newsreader (Serif) typography, with Geist (Sans) for UI copy and Geist Mono (Monospace) for data metrics.
+- **Search Modal (Cmd+K)**: Flat paper search interface with Smart Answers and activity sources.
+- **Collapsible Sidebar**: Zero border-radius sidebar with active states marked by clear border highlights.
+- **ScreenSearch Intel Dashboard**: AI-powered productivity insights with Daily Digest, Memory Status gauge, and a minimalist Productivity Pulse chart.
 
 ## Tech Stack
 
@@ -29,7 +29,7 @@ Modern React-based web interface for ScreenSearch, a Windows screen capture and 
 - **Vite** - Build tool and dev server
 - **TanStack Query** - Data fetching and caching
 - **Zustand** - Global state management
-- **Tailwind CSS** - Styling with custom glassmorphism utilities
+- **Tailwind CSS** - Styling with custom brutalist/paper theme tokens
 - **Framer Motion** - Animation library (v0.3.0+)
 - **Lucide React** - Icons
 - **React Hot Toast** - Notifications

--- a/screensearch-ui/index.html
+++ b/screensearch-ui/index.html
@@ -9,6 +9,10 @@
     <link rel="preconnect" href="http://localhost:3131" />
     <!-- Performance: Preload critical CSS -->
     <link rel="preload" as="style" href="/src/index.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400;1,6..72,500&family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/screensearch-ui/src/App.tsx
+++ b/screensearch-ui/src/App.tsx
@@ -92,14 +92,7 @@ function AppContent() {
       <Sidebar />
 
       {/* Main Content Area */}
-      <main className="flex-1 flex flex-col min-w-0 overflow-hidden relative">
-        {/* Background Decor */}
-        <div className="absolute inset-0 -z-10 h-full w-full bg-grid [mask-image:linear-gradient(to_bottom,transparent,black_10%,black_90%,transparent)] opacity-40 pointer-events-none" />
-        
-        {/* Ambient Light Blobs */}
-        <div className="bg-blob top-[-20%] left-[-10%]" />
-        <div className="bg-blob bg-blob-secondary bottom-[-20%] right-[-10%]" />
-
+      <main className="flex-1 flex flex-col min-w-0 overflow-hidden relative paper-grid">
         <div className="flex-1 overflow-y-auto flex flex-col">
           <div className="container mx-auto px-4 py-8 max-w-7xl flex-1">
             {activeTab === 'dashboard' && <DashboardPage />}

--- a/screensearch-ui/src/components/AiSettings.tsx
+++ b/screensearch-ui/src/components/AiSettings.tsx
@@ -61,10 +61,10 @@ export function AiSettings() {
     };
 
     return (
-        <div className="bg-card border border-border rounded-lg p-6 space-y-6">
-            <div className="flex items-center gap-2 pb-4 border-b border-border">
-                <Settings className="w-5 h-5 text-primary" />
-                <h2 className="text-lg font-semibold">AI Provider Settings</h2>
+        <div className="bg-paper border border-rule rounded-none p-6 space-y-6">
+            <div className="flex items-center gap-2 pb-4 border-b border-rule">
+                <Settings className="w-5 h-5 text-ink" />
+                <h2 className="text-[18px] font-serif text-ink">AI Provider Settings</h2>
             </div>
 
             <div className="space-y-4">
@@ -74,7 +74,7 @@ export function AiSettings() {
                     <select
                         value={isCustom ? 'custom' : aiConfig.providerUrl}
                         onChange={(e) => handleProviderChange(e.target.value)}
-                        className="w-full px-3 py-2 bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+                        className="w-full px-3 py-2 bg-paper-2 border border-rule rounded-none focus:outline-none focus:border-ink font-mono text-sm"
                     >
                         {PROVIDER_OPTIONS.map((option) => (
                             <option key={option.value} value={option.value}>
@@ -91,11 +91,11 @@ export function AiSettings() {
 
                 {/* Local Provider Info */}
                 {isLocal && (
-                    <div className="flex items-center gap-3 p-4 bg-primary/10 border border-primary/20 rounded-lg">
-                        <Cpu className="w-8 h-8 text-primary flex-shrink-0" />
+                    <div className="flex items-center gap-3 p-4 bg-paper-2 border border-rule rounded-none">
+                        <Cpu className="w-8 h-8 text-ink flex-shrink-0" />
                         <div>
-                            <p className="font-medium text-sm">Ministral-3B (Embedded)</p>
-                            <p className="text-xs text-muted-foreground">
+                            <p className="font-serif text-[15px]">Ministral-3B (Embedded)</p>
+                            <p className="text-xs font-serif italic text-muted">
                                 GPU-accelerated via Vulkan. Works on NVIDIA, AMD, and Intel GPUs.
                                 Model runs entirely on your machine - no API key required.
                             </p>
@@ -115,7 +115,7 @@ export function AiSettings() {
                                 setAiConfig({ providerUrl: e.target.value });
                             }}
                             placeholder="e.g., http://localhost:1234/v1"
-                            className="w-full px-3 py-2 bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+                            className="w-full px-3 py-2 bg-paper-2 border border-rule rounded-none focus:outline-none focus:border-ink font-mono text-sm"
                         />
                         <p className="text-xs text-muted-foreground">
                             For LM Studio or other OpenAI-compatible servers. Ensure path ends with <code>/v1</code>.
@@ -132,7 +132,7 @@ export function AiSettings() {
                             value={aiConfig.apiKey}
                             onChange={(e) => setAiConfig({ apiKey: e.target.value })}
                             placeholder="sk-..."
-                            className="w-full px-3 py-2 bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+                            className="w-full px-3 py-2 bg-paper-2 border border-rule rounded-none focus:outline-none focus:border-ink font-mono text-sm"
                         />
                     </div>
                 )}
@@ -146,7 +146,7 @@ export function AiSettings() {
                             value={aiConfig.model}
                             onChange={(e) => setAiConfig({ model: e.target.value })}
                             placeholder="e.g., llama3, gpt-4"
-                            className="w-full px-3 py-2 bg-background border border-input rounded-md focus:outline-none focus:ring-2 focus:ring-primary"
+                            className="w-full px-3 py-2 bg-paper-2 border border-rule rounded-none focus:outline-none focus:border-ink font-mono text-sm"
                         />
                     </div>
                 )}
@@ -155,7 +155,7 @@ export function AiSettings() {
                     <button
                         onClick={handleTestConnection}
                         disabled={isTesting}
-                        className="flex items-center gap-2 px-4 py-2 bg-secondary text-secondary-foreground rounded-md hover:bg-secondary/80 disabled:opacity-50 transition-colors"
+                        className="flex items-center gap-2 px-4 py-2 bg-paper hover:bg-paper-2 text-ink border border-rule rounded-none disabled:opacity-50 transition-colors"
                     >
                         {isTesting ? <Loader2 className="w-4 h-4 animate-spin" /> : null}
                         {isLocal ? 'Check Local Model' : 'Test Connection'}

--- a/screensearch-ui/src/components/FrameCard.tsx
+++ b/screensearch-ui/src/components/FrameCard.tsx
@@ -66,10 +66,10 @@ function FrameCardComponent({ frame, searchQuery = '' }: FrameCardProps) {
   }, [showTagMenu]);
 
   return (
-    <div className="group/card relative bg-card rounded-xl overflow-hidden shadow-sm hover:shadow-xl hover:shadow-primary/5 transition-all duration-300 ring-1 ring-border/50 hover:ring-primary/20 hover:-translate-y-1">
+    <div className="group/card relative bg-paper border border-rule hover:border-ink transition-all duration-300 hover:-translate-y-[2px]">
       {/* Image */}
       <div
-        className="relative aspect-video bg-muted/30 cursor-pointer overflow-hidden"
+        className="relative aspect-video bg-paper-2 border-b border-rule cursor-pointer overflow-hidden"
         onClick={() => setSelectedFrameId(frame.id)}
       >
         {imageUrl && !imageError ? (
@@ -89,7 +89,7 @@ function FrameCardComponent({ frame, searchQuery = '' }: FrameCardProps) {
         {/* Overlays */}
         <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-transparent to-transparent opacity-0 group-hover/card:opacity-100 transition-opacity duration-300" />
 
-        <div className="absolute top-3 right-3 px-2.5 py-1 bg-black/60 backdrop-blur-md text-white text-[10px] font-medium tracking-wide rounded-full border border-white/10 shadow-sm">
+        <div className="absolute top-3 right-3 px-2 py-1 bg-ink text-paper font-mono text-[10px] uppercase tracking-widest border border-ink shadow-sm">
           {formatRelativeTime(frame.timestamp)}
         </div>
       </div>
@@ -99,8 +99,8 @@ function FrameCardComponent({ frame, searchQuery = '' }: FrameCardProps) {
         {/* App Info */}
         <div className="flex items-start justify-between gap-3">
           <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
-              <div className="p-1.5 rounded-md bg-secondary text-primary">
+            <div className="flex items-center gap-2 text-sm font-semibold text-ink">
+              <div className="p-1.5 border border-rule bg-paper-2 text-ink">
                 <Monitor className="h-3 w-3" />
               </div>
               <span className="truncate">{frame.app_name}</span>
@@ -117,7 +117,7 @@ function FrameCardComponent({ frame, searchQuery = '' }: FrameCardProps) {
         {frame.description ? (
           <div className="space-y-1">
             <div className="flex items-center gap-2">
-              <span className="text-[10px] font-bold text-primary/80 uppercase tracking-widest px-1.5 py-0.5 rounded-sm bg-primary/10">
+              <span className="font-mono text-[10px] uppercase tracking-widest px-1.5 py-0.5 border border-rule text-ink bg-paper">
                 AI Summary
               </span>
               {frame.confidence !== undefined && (
@@ -149,14 +149,14 @@ function FrameCardComponent({ frame, searchQuery = '' }: FrameCardProps) {
           {frame.tags.map((tag) => (
             <div
               key={tag.id}
-              className="group/tag flex items-center gap-1 px-2 py-0.5 bg-secondary/50 hover:bg-secondary text-secondary-foreground rounded-md text-[10px] font-medium transition-colors border border-transparent hover:border-border"
+              className="group/tag flex items-center gap-1 px-2 py-0.5 border border-rule bg-paper hover:bg-paper-2 text-ink text-[10px] font-medium transition-colors"
               style={tag.color ? { backgroundColor: `${tag.color}20`, color: tag.color, borderColor: `${tag.color}40` } : undefined}
             >
               <TagIcon className="h-2.5 w-2.5" />
               <span>{tag.name}</span>
               <button
                 onClick={(e) => { e.stopPropagation(); handleRemoveTag(tag.id); }}
-                className="opacity-0 group-hover/tag:opacity-100 p-0.5 hover:bg-black/5 rounded-full transition-all"
+                className="opacity-0 group-hover/tag:opacity-100 p-0.5 hover:bg-rule rounded-none transition-all"
               >
                 <X className="h-2.5 w-2.5" />
               </button>
@@ -169,7 +169,7 @@ function FrameCardComponent({ frame, searchQuery = '' }: FrameCardProps) {
               onClick={() => setShowTagMenu(!showTagMenu)}
               aria-label="Add tag to frame"
               aria-expanded={showTagMenu}
-              className="opacity-0 group-hover/card:opacity-100 transition-opacity flex items-center gap-1 px-2 py-0.5 border border-dashed border-border rounded-md text-[10px] text-muted-foreground hover:text-foreground hover:bg-secondary/50"
+              className="opacity-0 group-hover/card:opacity-100 transition-opacity flex items-center gap-1 px-2 py-0.5 border border-dashed border-rule text-[10px] text-muted hover:text-ink hover:bg-paper-2"
             >
               <Plus className="h-2.5 w-2.5" />
               <span>Tag</span>
@@ -178,11 +178,11 @@ function FrameCardComponent({ frame, searchQuery = '' }: FrameCardProps) {
             {/* Tag Menu */}
             {showTagMenu && availableTags.length > 0 && (
               <div
-                className="absolute top-full left-0 mt-2 bg-popover border border-border rounded-lg shadow-xl shadow-black/10 z-50 min-w-[160px] p-1 animate-in fade-in zoom-in-95 duration-100"
+                className="absolute top-full left-0 mt-2 bg-paper border border-ink shadow-hard z-50 min-w-[160px] p-1 animate-in fade-in zoom-in-95 duration-100"
                 role="menu"
                 aria-label="Available tags"
               >
-                <div className="text-[10px] font-medium text-muted-foreground px-2 py-1.5 uppercase tracking-wider">
+                <div className="font-mono text-[10px] text-muted px-2 py-1.5 uppercase tracking-wider">
                   Select Tag
                 </div>
                 <div className="max-h-32 overflow-y-auto">
@@ -191,7 +191,7 @@ function FrameCardComponent({ frame, searchQuery = '' }: FrameCardProps) {
                       key={tag.id}
                       onClick={() => handleAddTag(tag.id)}
                       role="menuitem"
-                      className="w-full px-2 py-1.5 text-left text-xs hover:bg-accent rounded-md transition-colors flex items-center gap-2"
+                      className="w-full px-2 py-1.5 text-left text-xs hover:bg-paper-2 border border-transparent hover:border-rule transition-colors flex items-center gap-2"
                     >
                       <div
                         className="w-2 h-2 rounded-full ring-1 ring-inset ring-black/10"

--- a/screensearch-ui/src/components/SearchBar.tsx
+++ b/screensearch-ui/src/components/SearchBar.tsx
@@ -63,11 +63,8 @@ export function SearchBar() {
     <div className="space-y-6 w-full max-w-4xl mx-auto">
       {/* Main Search Bar */}
       <div className="relative group z-30" ref={autocompleteRef}>
-        <div className="relative transition-all duration-300 transform group-hover:-translate-y-0.5 group-focus-within:-translate-y-1">
-          {/* Glow effect */}
-          <div className="absolute inset-0 bg-gradient-to-r from-primary/30 via-primary-light/20 to-primary/10 rounded-2xl blur-xl opacity-0 group-focus-within:opacity-100 transition-opacity duration-500" />
-
-          <div className="relative glass-card rounded-2xl group-hover:border-primary/30 group-focus-within:border-primary/50 group-focus-within:shadow-xl transition-all duration-300">
+        <div className="relative transition-all duration-300 transform">
+          <div className="relative bg-paper border border-rule rounded-none group-focus-within:border-ink transition-all duration-300">
             <Search className="absolute left-4 top-1/2 -translate-y-1/2 h-5 w-5 text-muted-foreground group-focus-within:text-primary transition-colors" />
             <input
               type="text"
@@ -78,7 +75,7 @@ export function SearchBar() {
               }}
               onFocus={() => setShowAutocomplete(true)}
               placeholder="What did I work on yesterday?"
-              className="w-full pl-12 pr-12 py-4 bg-transparent border-none rounded-2xl text-lg placeholder:text-muted-foreground/50 focus:outline-none focus:ring-0"
+              className="w-full pl-12 pr-12 py-4 bg-transparent border-none rounded-none text-lg font-serif italic placeholder:text-muted/50 focus:outline-none focus:ring-0"
             />
             {localQuery && (
               <button
@@ -86,7 +83,7 @@ export function SearchBar() {
                   setLocalQuery('');
                   setFilters({ searchQuery: '' });
                 }}
-                className="absolute right-4 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground bg-muted/50 hover:bg-muted rounded-full transition-all"
+                className="absolute right-4 top-1/2 -translate-y-1/2 p-1 text-muted hover:text-ink bg-paper-2 hover:bg-rule rounded-none transition-all border border-rule"
               >
                 <X className="h-4 w-4" />
               </button>
@@ -96,7 +93,7 @@ export function SearchBar() {
 
         {/* Autocomplete Dropdown */}
         {showAutocomplete && suggestions.length > 0 && (
-          <div className="absolute top-full left-0 right-0 mt-3 glass-card z-50 max-h-80 overflow-y-auto animate-fade-in-up">
+          <div className="absolute top-full left-0 right-0 mt-3 bg-paper border border-ink z-50 max-h-80 overflow-y-auto animate-fade-in-up">
             <div className="p-2 space-y-1">
               {suggestions.map((suggestion, index) => (
                 <button
@@ -106,9 +103,9 @@ export function SearchBar() {
                     setFilters({ searchQuery: suggestion });
                     setShowAutocomplete(false);
                   }}
-                  className="w-full px-4 py-3 text-left hover:bg-primary/5 hover:text-primary rounded-lg transition-all flex items-center gap-3 group/item"
+                  className="w-full px-4 py-3 text-left hover:bg-paper-2 hover:text-ink border-b border-rule last:border-0 rounded-none transition-all flex items-center gap-3 group/item"
                 >
-                  <Search className="h-4 w-4 text-muted-foreground group-hover/item:text-primary/70" />
+                  <Search className="h-4 w-4 text-muted group-hover/item:text-ink" />
                   <span className="font-medium">{suggestion}</span>
                 </button>
               ))}
@@ -119,14 +116,14 @@ export function SearchBar() {
 
       {/* Search Mode Toggle */}
       <div className="flex justify-center">
-        <div className="bg-secondary/50 p-1 rounded-lg flex items-center gap-1 border border-border/50">
+        <div className="bg-paper-2 p-1 rounded-none flex items-center gap-1 border border-rule">
           {(['fts', 'semantic'] as const).map((mode) => (
             <button
               key={mode}
               onClick={() => setFilters({ searchMode: mode })}
-              className={`px-3 py-1.5 rounded-md text-xs font-medium transition-all ${filters.searchMode === mode
-                  ? 'bg-background text-foreground shadow-sm ring-1 ring-border'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-background/50'
+              className={`px-3 py-1.5 rounded-none text-xs font-mono uppercase tracking-wider transition-all ${filters.searchMode === mode
+                  ? 'bg-ink text-paper shadow-none ring-0'
+                  : 'text-ink hover:text-ink hover:bg-rule-2'
                 }`}
             >
               {mode === 'fts' ? 'Exact Match' : 'Smart Search'}
@@ -140,8 +137,8 @@ export function SearchBar() {
         <div className="flex items-center gap-4 text-sm text-muted-foreground">
           {hasActiveFilters && (
             <div className="flex items-center gap-2 animate-fade-in">
-              <span className="w-1.5 h-1.5 rounded-full bg-primary" />
-              <span className="font-medium text-primary">Filters active</span>
+              <span className="w-1.5 h-1.5 rounded-full bg-ink" />
+              <span className="font-serif text-[15px] text-ink">Filters active</span>
             </div>
           )}
         </div>
@@ -150,7 +147,7 @@ export function SearchBar() {
           {hasActiveFilters && (
             <button
               onClick={resetFilters}
-              className="text-sm text-muted-foreground hover:text-destructive transition-colors px-3 py-1.5 rounded-lg hover:bg-destructive/5"
+              className="text-sm text-ink hover:text-warn transition-colors px-3 py-1.5 rounded-none border border-transparent hover:border-warn hover:bg-paper-2"
             >
               Clear all
             </button>
@@ -158,25 +155,25 @@ export function SearchBar() {
 
           <button
             onClick={() => setShowFilters(!showFilters)}
-            className={`flex items-center gap-2 px-4 py-2 rounded-xl transition-all duration-200 border ${showFilters
-              ? 'bg-secondary text-secondary-foreground border-border'
-              : 'bg-background hover:bg-secondary/50 text-muted-foreground hover:text-foreground border-transparent'
+            className={`flex items-center gap-2 px-4 py-2 rounded-none transition-all duration-200 border ${showFilters
+              ? 'bg-paper-2 text-ink border-rule'
+              : 'bg-paper hover:bg-paper-2 text-muted hover:text-ink border-rule'
               }`}
           >
             <Calendar className={`h-4 w-4 ${showFilters ? 'text-primary' : ''}`} />
-            <span className="font-medium">Filters</span>
+            <span className="font-serif text-[15px]">Filters</span>
           </button>
         </div>
       </div>
 
       {/* Filter Panel */}
       {showFilters && (
-        <div className="glass-card p-6 space-y-6 animate-fade-in-up">
+        <div className="bg-paper border border-rule p-6 space-y-6 animate-fade-in-up">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
             {/* Left Column */}
             <div className="space-y-4">
-              <label className="text-sm font-semibold flex items-center gap-2 text-foreground">
-                <Calendar className="h-4 w-4 text-primary" />
+              <label className="text-sm font-serif text-[18px] flex items-center gap-2 text-ink">
+                <Calendar className="h-4 w-4 text-muted" />
                 Date Range
               </label>
               <div className="grid grid-cols-2 gap-3">
@@ -193,7 +190,7 @@ export function SearchBar() {
                         },
                       })
                     }
-                    className="w-full px-3 py-2.5 bg-background border border-border rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary/50 outline-none transition-all"
+                    className="w-full px-3 py-2 bg-paper-2 border border-rule rounded-none text-sm font-mono focus:border-ink outline-none transition-all"
                   />
                 </div>
                 <div className="space-y-1.5">
@@ -209,7 +206,7 @@ export function SearchBar() {
                         },
                       })
                     }
-                    className="w-full px-3 py-2.5 bg-background border border-border rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary/50 outline-none transition-all"
+                    className="w-full px-3 py-2 bg-paper-2 border border-rule rounded-none text-sm font-mono focus:border-ink outline-none transition-all"
                   />
                 </div>
               </div>
@@ -217,8 +214,8 @@ export function SearchBar() {
 
             {/* Right Column */}
             <div className="space-y-4">
-              <label className="text-sm font-semibold flex items-center gap-2 text-foreground">
-                <Monitor className="h-4 w-4 text-primary" />
+              <label className="text-sm font-serif text-[18px] flex items-center gap-2 text-ink">
+                <Monitor className="h-4 w-4 text-muted" />
                 Application
               </label>
               <div className="space-y-1.5">
@@ -232,18 +229,18 @@ export function SearchBar() {
                       applications: e.target.value ? [e.target.value] : [],
                     })
                   }
-                  className="w-full px-4 py-2.5 bg-background border border-border rounded-xl text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary/50 outline-none transition-all"
+                  className="w-full px-4 py-2 bg-paper-2 border border-rule rounded-none text-sm font-sans focus:border-ink outline-none transition-all"
                 />
               </div>
             </div>
           </div>
 
-          <div className="h-px bg-border/50" />
+          <div className="h-px bg-rule" />
 
           {/* Tag Filter */}
           <div className="space-y-3">
-            <label className="text-sm font-semibold flex items-center gap-2 text-foreground">
-              <TagIcon className="h-4 w-4 text-primary" />
+            <label className="text-sm font-serif text-[18px] flex items-center gap-2 text-ink">
+              <TagIcon className="h-4 w-4 text-muted" />
               Tags
             </label>
             <div className="flex flex-wrap gap-2">
@@ -259,9 +256,9 @@ export function SearchBar() {
                           : [...filters.tags, tag.id],
                       });
                     }}
-                    className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all duration-200 border ${isSelected
-                      ? 'bg-primary/10 text-primary border-primary/20 scale-105 shadow-sm'
-                      : 'bg-secondary/50 text-muted-foreground border-transparent hover:bg-secondary hover:text-foreground'
+                    className={`px-3 py-1.5 rounded-none text-[11px] font-mono uppercase tracking-wider transition-all duration-200 border ${isSelected
+                      ? 'bg-ink text-paper border-ink shadow-none'
+                      : 'bg-paper-2 text-ink border-rule hover:bg-rule hover:text-ink'
                       }`}
                     style={
                       isSelected && tag.color

--- a/screensearch-ui/src/components/SettingsPanel.tsx
+++ b/screensearch-ui/src/components/SettingsPanel.tsx
@@ -309,18 +309,18 @@ export function SettingsPanel() {
   return (
     <>
       <div
-        className="fixed inset-0 bg-black/50 backdrop-blur-sm z-40 animate-fade-in"
+        className="fixed inset-0 bg-ink/30 z-40 animate-fade-in"
         onClick={toggleSettingsPanel}
       />
 
-      <div className="fixed right-0 top-0 bottom-0 w-full max-w-2xl bg-background border-l border-border z-50 flex flex-col animate-slide-in shadow-2xl">
+      <div className="fixed right-0 top-0 bottom-0 w-full max-w-2xl bg-paper border-l border-rule z-50 flex flex-col animate-slide-in shadow-hard">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-border">
           <div className="flex items-center gap-3">
-            <SettingsIcon className="h-6 w-6 text-primary" />
+            <SettingsIcon className="h-6 w-6 text-ink" />
             <div>
-              <h2 className="text-2xl font-bold">Settings</h2>
-              <p className="text-sm text-muted-foreground">Manage your ScreenSearch preferences</p>
+              <h2 className="text-[26px] font-serif text-ink">Settings</h2>
+              <p className="text-sm font-serif italic text-muted">Manage your ScreenSearch preferences</p>
             </div>
           </div>
           <button
@@ -332,7 +332,7 @@ export function SettingsPanel() {
         </div>
 
         {/* Tab Navigation */}
-        <div className="flex px-6 border-b border-border overflow-x-auto">
+        <div className="flex px-6 border-b border-rule overflow-x-auto bg-paper-2">
           {tabs.map((tab) => {
             const Icon = tab.icon;
             return (
@@ -340,10 +340,10 @@ export function SettingsPanel() {
                 key={tab.id}
                 onClick={() => setActiveTab(tab.id)}
                 className={cn(
-                  "flex items-center gap-2 px-6 py-4 text-sm font-medium border-b-2 transition-colors whitespace-nowrap",
+                  "flex items-center gap-2 px-6 py-4 text-sm font-mono uppercase tracking-wider border-r border-rule transition-colors whitespace-nowrap",
                   activeTab === tab.id
-                    ? "border-primary text-primary"
-                    : "border-transparent text-muted-foreground hover:text-foreground hover:border-border"
+                    ? "bg-paper text-ink"
+                    : "text-muted hover:text-ink hover:bg-paper"
                 )}
               >
                 <Icon className="h-4 w-4" />
@@ -361,23 +361,23 @@ export function SettingsPanel() {
             {activeTab === 'general' && (
               <div className="space-y-6 animate-in fade-in slide-in-from-bottom-4 duration-300">
                 <section className="space-y-4">
-                  <h3 className="text-lg font-semibold border-b border-border pb-2">Appearance</h3>
-                  <div className="flex items-center justify-between p-4 bg-card rounded-xl border border-border">
+                  <h3 className="text-lg font-serif border-b border-rule pb-2 text-ink">Appearance</h3>
+                  <div className="flex items-center justify-between p-4 bg-paper border border-rule">
                     <div>
-                      <p className="font-medium">Dark Mode</p>
-                      <p className="text-sm text-muted-foreground">Toggle application theme</p>
+                      <p className="font-mono text-sm uppercase tracking-wider text-ink">Dark Mode</p>
+                      <p className="text-sm font-serif italic text-muted">Toggle application theme</p>
                     </div>
                     <button
                       onClick={toggleDarkMode}
                       className={cn(
-                        "relative w-14 h-7 rounded-full transition-colors",
-                        isDarkMode ? 'bg-primary' : 'bg-secondary'
+                        "relative w-14 h-7 rounded-none transition-colors border border-rule",
+                        isDarkMode ? 'bg-ink' : 'bg-paper-2'
                       )}
                     >
                       <div
                         className={cn(
-                          "absolute top-0.5 left-0.5 w-6 h-6 bg-white rounded-full transition-transform",
-                          isDarkMode ? 'translate-x-7' : 'translate-x-0'
+                          "absolute top-0.5 left-0.5 w-6 h-6 transition-transform border border-rule",
+                          isDarkMode ? 'translate-x-7 bg-paper border-ink' : 'translate-x-0 bg-paper'
                         )}
                       />
                     </button>
@@ -385,7 +385,7 @@ export function SettingsPanel() {
                 </section>
 
                 <section className="space-y-4">
-                  <h3 className="text-lg font-semibold border-b border-border pb-2">Application</h3>
+                  <h3 className="text-lg font-serif border-b border-rule pb-2 text-ink">Application</h3>
                   <TagManager />
                 </section>
               </div>

--- a/screensearch-ui/src/components/Sidebar.tsx
+++ b/screensearch-ui/src/components/Sidebar.tsx
@@ -44,21 +44,16 @@ export function Sidebar() {
                 disabled={isDisabled}
                 title={isSidebarCollapsed ? item.label : undefined}
                 className={cn(
-                    "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all duration-300 relative overflow-hidden group",
+                    "w-full flex items-center gap-3 px-3 py-2.5 text-sm font-medium transition-all duration-200 relative group border-l-2",
                     isSidebarCollapsed && "justify-center",
                     isActive && !isDisabled
-                        ? "active-border bg-primary/10 text-primary"
+                        ? "border-ink bg-paper-2 text-ink"
                         : isDisabled
-                            ? "text-muted-foreground/50 cursor-not-allowed"
-                            : "text-muted-foreground hover:bg-surface-2 hover:text-foreground hover:glow-cyan-subtle"
+                            ? "border-transparent text-muted/50 cursor-not-allowed"
+                            : "border-transparent text-muted hover:bg-paper-2 hover:text-ink hover:border-rule"
                 )}
             >
-                {/* Active Indicator Glimmer */}
-                {isActive && !isDisabled && (
-                  <div className="absolute inset-0 bg-gradient-to-r from-transparent via-primary/10 to-transparent translate-x-[-100%] animate-[shimmer_2s_infinite]" />
-                )}
-                
-                <Icon className={cn("h-4 w-4 flex-shrink-0 transition-colors duration-300", isActive && "text-primary drop-shadow-[0_0_8px_rgba(0,242,255,0.6)]")} />
+                <Icon className={cn("h-4 w-4 flex-shrink-0 transition-colors duration-200", isActive && "text-ink")} />
 
                 <AnimatePresence mode="wait">
                     {!isSidebarCollapsed && (
@@ -69,9 +64,9 @@ export function Sidebar() {
                             transition={{ duration: 0.2 }}
                             className="flex items-center justify-between flex-1 overflow-hidden"
                         >
-                            <span className={cn("whitespace-nowrap transition-all duration-300", isActive && "neon-text")}>{item.label}</span>
+                            <span className={cn("whitespace-nowrap transition-all duration-200 font-sans")}>{item.label}</span>
                             {item.comingSoon && (
-                                <span className="badge-coming-soon text-[10px] px-1.5 ml-2">Soon</span>
+                                <span className="font-mono text-[10px] text-muted uppercase tracking-wider px-1.5 py-0.5 border border-rule">Soon</span>
                             )}
                         </motion.div>
                     )}
@@ -84,25 +79,25 @@ export function Sidebar() {
         <motion.div
             animate={{ width: isSidebarCollapsed ? 72 : 256 }}
             transition={{ duration: 0.3, ease: [0.4, 0, 0.2, 1] }}
-            className="h-screen glass-panel border-r border-border flex flex-col z-10"
+            className="h-screen bg-paper border-r border-rule flex flex-col z-10"
         >
             {/* Logo */}
             <div className={cn(
-                "p-4 flex items-center",
+                "p-4 flex items-center border-b border-rule",
                 isSidebarCollapsed ? "justify-center" : "px-6"
             )}>
                 <Logo collapsed={isSidebarCollapsed} />
             </div>
 
             {/* Search Shortcut */}
-            <div className={cn("px-4 mb-4", isSidebarCollapsed && "px-2")}>
+            <div className={cn("p-4 border-b border-rule", isSidebarCollapsed && "px-2")}>
                 <button
                     onClick={openSearchModal}
                     title={isSidebarCollapsed ? "Search (⌘K)" : undefined}
                     className={cn(
-                        "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm",
-                        "bg-surface-1 hover:bg-surface-2 border border-border hover:border-primary/30",
-                        "text-muted-foreground hover:text-foreground transition-all",
+                        "w-full flex items-center gap-3 px-3 py-2.5 text-sm",
+                        "bg-paper-2 hover:bg-rule-2 border border-rule",
+                        "text-ink transition-all rounded-none",
                         isSidebarCollapsed && "justify-center"
                     )}
                 >
@@ -116,12 +111,12 @@ export function Sidebar() {
                                 transition={{ duration: 0.2 }}
                                 className="flex items-center justify-between flex-1 overflow-hidden"
                             >
-                                <span className="whitespace-nowrap">Search...</span>
-                                <div className="flex items-center gap-0.5 text-xs">
-                                    <kbd className="px-1.5 py-0.5 bg-surface-2 rounded text-[10px]">
+                                <span className="whitespace-nowrap font-serif italic text-[15px]">Search...</span>
+                                <div className="flex items-center gap-1 text-xs">
+                                    <kbd className="px-1.5 py-0.5 bg-paper border border-rule font-mono text-[10px]">
                                         <Command className="h-2.5 w-2.5 inline" />
                                     </kbd>
-                                    <kbd className="px-1.5 py-0.5 bg-surface-2 rounded text-[10px]">K</kbd>
+                                    <kbd className="px-1.5 py-0.5 bg-paper border border-rule font-mono text-[10px]">K</kbd>
                                 </div>
                             </motion.div>
                         )}
@@ -130,7 +125,7 @@ export function Sidebar() {
             </div>
 
             {/* Navigation */}
-            <div className="flex-1 px-3 space-y-6 overflow-y-auto overflow-x-hidden">
+            <div className="flex-1 py-4 space-y-6 overflow-y-auto overflow-x-hidden">
                 {/* Main Navigation */}
                 <div className="space-y-1">
                     <AnimatePresence mode="wait">
@@ -139,7 +134,7 @@ export function Sidebar() {
                                 initial={{ opacity: 0 }}
                                 animate={{ opacity: 1 }}
                                 exit={{ opacity: 0 }}
-                                className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3 px-2"
+                                className="font-mono text-[11px] text-muted uppercase tracking-[0.12em] mb-3 px-4"
                             >
                                 Menu
                             </motion.div>
@@ -156,7 +151,7 @@ export function Sidebar() {
                                 initial={{ opacity: 0 }}
                                 animate={{ opacity: 1 }}
                                 exit={{ opacity: 0 }}
-                                className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3 px-2"
+                                className="font-mono text-[11px] text-muted uppercase tracking-[0.12em] mb-3 px-4"
                             >
                                 AI Features
                             </motion.div>
@@ -167,14 +162,14 @@ export function Sidebar() {
             </div>
 
             {/* Footer Actions */}
-            <div className="p-3 border-t border-border space-y-1">
+            <div className="p-3 border-t border-rule space-y-1 bg-paper-2/50">
                 {/* Settings */}
                 <button
                     onClick={toggleSettingsPanel}
                     title={isSidebarCollapsed ? "Settings" : undefined}
                     className={cn(
-                        "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium",
-                        "text-muted-foreground hover:bg-surface-2 hover:text-foreground transition-all duration-200",
+                        "w-full flex items-center gap-3 px-3 py-2.5 text-sm font-medium border-l-2 border-transparent",
+                        "text-muted hover:bg-rule-2 hover:text-ink transition-all duration-200",
                         isSidebarCollapsed && "justify-center"
                     )}
                 >
@@ -186,7 +181,7 @@ export function Sidebar() {
                                 animate={{ opacity: 1, width: 'auto' }}
                                 exit={{ opacity: 0, width: 0 }}
                                 transition={{ duration: 0.2 }}
-                                className="whitespace-nowrap"
+                                className="whitespace-nowrap font-sans"
                             >
                                 Settings
                             </motion.span>
@@ -199,8 +194,8 @@ export function Sidebar() {
                     onClick={toggleSidebar}
                     title={isSidebarCollapsed ? "Expand sidebar" : "Collapse sidebar"}
                     className={cn(
-                        "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium",
-                        "text-muted-foreground hover:bg-surface-2 hover:text-foreground transition-all duration-200",
+                        "w-full flex items-center gap-3 px-3 py-2.5 text-sm font-medium border-l-2 border-transparent",
+                        "text-muted hover:bg-rule-2 hover:text-ink transition-all duration-200",
                         isSidebarCollapsed && "justify-center"
                     )}
                 >
@@ -217,7 +212,7 @@ export function Sidebar() {
                                 animate={{ opacity: 1, width: 'auto' }}
                                 exit={{ opacity: 0, width: 0 }}
                                 transition={{ duration: 0.2 }}
-                                className="whitespace-nowrap"
+                                className="whitespace-nowrap font-sans"
                             >
                                 Collapse
                             </motion.span>

--- a/screensearch-ui/src/components/Timeline.tsx
+++ b/screensearch-ui/src/components/Timeline.tsx
@@ -100,18 +100,18 @@ export function Timeline() {
             <div className="flex items-center gap-2">
               <button
                 onClick={() => setViewMode('grid')}
-                className={`p-2 rounded-lg transition-colors ${viewMode === 'grid'
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+                className={`p-2 transition-colors border border-rule ${viewMode === 'grid'
+                  ? 'bg-ink text-paper'
+                  : 'bg-paper text-ink hover:bg-paper-2'
                   }`}
               >
                 <Grid className="h-4 w-4" />
               </button>
               <button
                 onClick={() => setViewMode('list')}
-                className={`p-2 rounded-lg transition-colors ${viewMode === 'list'
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+                className={`p-2 transition-colors border border-rule ${viewMode === 'list'
+                  ? 'bg-ink text-paper'
+                  : 'bg-paper text-ink hover:bg-paper-2'
                   }`}
               >
                 <List className="h-4 w-4" />
@@ -134,16 +134,16 @@ export function Timeline() {
               {Object.entries(framesByDate).map(([date, frames]) => (
                 <div key={date} className="relative space-y-6">
                   {/* Date Header */}
-                  <div className="sticky top-0 z-20 py-4 -mx-4 px-4 bg-background/95 backdrop-blur-sm border-b border-border/40 transition-all duration-200">
+                  <div className="sticky top-0 z-20 py-4 -mx-4 px-4 bg-paper border-b border-rule">
                     <div className="flex items-baseline gap-3">
-                      <h2 className="text-2xl font-bold tracking-tight text-foreground">
+                      <h2 className="text-[26px] font-serif text-ink">
                         {format(new Date(date), 'EEEE')}
                       </h2>
-                      <div className="h-1 w-1 rounded-full bg-muted-foreground/30" />
-                      <p className="text-muted-foreground font-medium">
+                      <div className="h-1 w-1 rounded-full bg-muted/30" />
+                      <p className="text-muted font-serif italic">
                         {format(new Date(date), 'MMMM d, yyyy')}
                       </p>
-                      <div className="ml-auto text-xs font-mono text-muted-foreground/50 tabular-nums px-2 py-0.5 rounded-md bg-secondary/30">
+                      <div className="ml-auto text-xs font-mono text-muted tabular-nums px-2 py-0.5 border border-rule bg-paper-2">
                         {frames.length} captures
                       </div>
                     </div>
@@ -176,7 +176,7 @@ export function Timeline() {
               <button
                 onClick={() => setPage(Math.max(0, page - 1))}
                 disabled={page === 0}
-                className="px-4 py-2 text-sm font-medium text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                className="px-4 py-2 text-sm font-medium text-ink hover:text-ink disabled:opacity-50 disabled:cursor-not-allowed border border-rule bg-paper hover:bg-paper-2 transition-colors"
               >
                 Previous
               </button>

--- a/screensearch-ui/src/components/ui/GlassCard.tsx
+++ b/screensearch-ui/src/components/ui/GlassCard.tsx
@@ -18,34 +18,19 @@ const paddingClasses = {
   lg: 'p-6',
 };
 
-const glowClasses: Record<GlowColor, string> = {
-  cyan: 'glow-cyan-subtle border-gradient-cyan',
-  green: 'shadow-[0_0_20px_-5px_rgba(0,255,136,0.2)]',
-  purple: 'shadow-[0_0_20px_-5px_rgba(168,85,247,0.2)]',
-  none: '',
-};
-
 export function GlassCard({
   children,
   className,
   hover = false,
-  glow = false,
   padding = 'md',
 }: GlassCardProps) {
-  // Handle glow prop - can be boolean or color string
-  const glowClass = typeof glow === 'string'
-    ? glowClasses[glow]
-    : glow
-      ? 'animate-border-glow'
-      : '';
 
   return (
     <div
       className={cn(
-        'glass-card',
+        'bg-paper border border-rule',
         paddingClasses[padding],
-        hover && 'glass-card-hover cursor-pointer',
-        glowClass,
+        hover && 'hover:bg-paper-2 hover:border-ink transition-colors cursor-pointer',
         className
       )}
     >
@@ -68,12 +53,12 @@ export function GlassCardHeader({
   badge,
 }: GlassCardHeaderProps) {
   return (
-    <div className={cn('flex items-center justify-between mb-4', className)}>
+    <div className={cn('flex items-center justify-between mb-4 pb-4 border-b border-rule', className)}>
       <div className="flex items-center gap-2">
         {icon && (
-          <span className="text-primary">{icon}</span>
+          <span className="text-ink">{icon}</span>
         )}
-        <h3 className="font-semibold text-foreground">{children}</h3>
+        <h3 className="font-serif text-[18px] text-ink">{children}</h3>
       </div>
       {badge}
     </div>
@@ -90,7 +75,7 @@ export function GlassCardContent({
   className,
 }: GlassCardContentProps) {
   return (
-    <div className={cn('text-muted-foreground', className)}>
+    <div className={cn('text-ink-2', className)}>
       {children}
     </div>
   );

--- a/screensearch-ui/src/index.css
+++ b/screensearch-ui/src/index.css
@@ -4,105 +4,62 @@
 
 @layer base {
   :root {
-    /* Premium Light Mode - Blue System (matching screensearch.app) */
-    --background: 0 0% 100%;
-    --foreground: 222 47% 11%;           /* Slate 900 - #0f172a */
-    --card: 0 0% 100%;
-    --card-foreground: 222 47% 11%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 11%;
+    /* Light Mode - Brutalist Paper (screensearch.app) */
+    
+    /* Using HSL to be compatible with tailwind mapping */
+    /* 
+      --ink: #0d1320 -> hsl(221, 42%, 9%)
+      --ink-2: #2a3142 -> hsl(223, 22%, 21%)
+      --muted: #5b6273 -> hsl(223, 12%, 40%)
+      --rule: #e6e3dc -> hsl(42, 17%, 88%)
+      --rule-2: #d8d4cb -> hsl(42, 16%, 82%)
+      --paper: #faf8f3 -> hsl(43, 33%, 96%)
+      --paper-2: #f3efe6 -> hsl(42, 33%, 93%)
+      --accent: #1f3a8a -> hsl(225, 63%, 33%)
+      --accent-ink: #122463 -> hsl(227, 69%, 23%)
+      --warn: #8a1c1c -> hsl(0, 66%, 33%)
+      --good: #14532d -> hsl(144, 61%, 20%)
+    */
+    
+    --ink: 221 42% 9%;
+    --ink-2: 223 22% 21%;
+    --muted: 223 12% 40%;
+    --rule: 42 17% 88%;
+    --rule-2: 42 16% 82%;
+    --paper: 43 33% 96%;
+    --paper-2: 42 33% 93%;
+    --accent: 225 63% 33%;
+    --accent-ink: 227 69% 23%;
+    --warn: 0 66% 33%;
+    --good: 144 61% 20%;
 
-    /* Primary Blue Palette */
-    --primary: 217 91% 60%;              /* Blue 600 - #2563eb */
-    --primary-light: 213 94% 68%;        /* Blue 400 - #60a5fa */
-    --primary-dark: 221 83% 53%;         /* Blue 500 - #3b82f6 */
-    --primary-foreground: 210 40% 98%;
-
-    --secondary: 214 32% 91%;            /* Slate 200 */
-    --secondary-foreground: 222 47% 11%;
-
-    --muted: 210 40% 96%;
-    --muted-foreground: 215 16% 47%;     /* Slate 500 */
-
-    --accent: 214 32% 91%;
-    --accent-foreground: 222 47% 11%;
-
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 98%;
-
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 217 91% 60%;
-
-    --radius: 0.75rem;
-
-    /* Glassmorphism (light mode - subtle) */
-    --glass-bg: rgba(255, 255, 255, 0.7);
-    --glass-border: rgba(37, 99, 235, 0.1);
-    --glass-glow: rgba(37, 99, 235, 0.15);
+    --background: var(--paper);
+    --foreground: var(--ink);
   }
 
   .dark {
-    /* Deep Space Background (from concept art) */
-    --background: 220 25% 6%;            /* #0d1117 - deep space */
-    --background-elevated: 220 20% 10%;  /* #151b23 - elevated surfaces */
-    --foreground: 210 40% 98%;
+    /* Dark Mode - Inverted Brutalist Theme */
+    
+    /*
+      Inverted logic:
+      --ink: Light text (formerly paper)
+      --paper: Dark background (formerly ink)
+    */
+    
+    --ink: 43 33% 96%;        /* #faf8f3 */
+    --ink-2: 42 16% 82%;      /* #d8d4cb */
+    --muted: 223 12% 40%;     /* #5b6273 (keep similar) */
+    --rule: 223 22% 21%;      /* #2a3142 */
+    --rule-2: 221 42% 15%;    /* Slightly lighter than ink */
+    --paper: 221 42% 9%;      /* #0d1320 */
+    --paper-2: 223 22% 15%;   /* Slightly elevated */
+    --accent: 225 63% 53%;    /* Lighter blue */
+    --accent-ink: 227 69% 63%;/* Even lighter blue */
+    --warn: 0 66% 60%;        /* Lighter red */
+    --good: 144 61% 50%;      /* Lighter green */
 
-    --card: 220 20% 10%;                 /* Slightly lighter for cards */
-    --card-foreground: 210 40% 98%;
-
-    --popover: 220 20% 10%;
-    --popover-foreground: 210 40% 98%;
-
-    /* Cyan Accent System (from concept art) */
-    --primary: 190 95% 50%;              /* #00d4ff - main cyan */
-    --primary-light: 190 100% 60%;       /* #33e0ff - glow effect */
-    --primary-dark: 190 80% 45%;         /* Darker cyan */
-    --primary-foreground: 220 25% 6%;    /* Dark text on cyan */
-
-    /* Dark Theme Colors - Slightly Brightened */
-    --background: 222 47% 8%;            /* Was 222 47% 4% (too dark) - now #0b111c */
-    --background-elevated: 222 47% 12%;  /* Slightly lighter */
-    --foreground: 210 40% 98%;
-
-    --card: 222 47% 10%;                 /* Slightly lighter card */
-    --card-foreground: 210 40% 98%;
-
-    --popover: 222 47% 10%;
-    --popover-foreground: 210 40% 98%;
-
-    /* Accent variants for flexibility */
-    --accent-primary: 190 95% 50%;       /* Main cyan */
-    --accent-glow: 190 100% 60%;         /* Glow cyan */
-    --accent-muted: 190 50% 30%;         /* Subtle cyan #265a66 */
-    --accent-green: 160 80% 50%;         /* Green accent for success states */
-
-    --secondary: 220 20% 14%;            /* Surface 2 - elevated cards */
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: 220 20% 14%;
-    --muted-foreground: 215 20% 65%;
-
-    --accent: 220 20% 14%;
-    --accent-foreground: 210 40% 98%;
-
-    --destructive: 0 63% 31%;
-    --destructive-foreground: 210 40% 98%;
-
-    /* Surface Hierarchy */
-    --surface-1: 220 20% 10%;            /* Cards */
-    --surface-2: 220 20% 14%;            /* Elevated cards */
-    --surface-3: 220 20% 18%;            /* Hover states */
-
-    --border: 190 50% 25%;               /* Cyan-tinted border */
-    --input: 220 20% 14%;
-    --ring: 190 95% 50%;
-
-    /* Glassmorphism (dark mode - prominent with cyan) */
-    --glass-bg: rgba(13, 17, 23, 0.4); /* Reduced opacity from 0.6 */
-    --glass-border: rgba(255, 255, 255, 0.08); /* Lighter border for contrast */
-    --glass-blur: 24px; /* Increased blur */
-    --glass-glow: rgba(0, 212, 255, 0.1); /* Subtle ambient glow */
+    --background: var(--paper);
+    --foreground: var(--ink);
   }
 }
 
@@ -112,196 +69,86 @@
   }
 
   body {
-    @apply bg-background text-foreground;
-    /* Sci-Fi Atmospheric Depth */
-    background-image: radial-gradient(circle at 50% 0%, #1a2333 0%, #020617 100%);
-    background-attachment: fixed;
+    @apply bg-paper text-ink font-sans;
+    font-feature-settings: "ss01", "cv11";
+    -webkit-font-smoothing: antialiased;
   }
 }
 
 /* Custom Scrollbar */
 ::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
 }
 
 ::-webkit-scrollbar-track {
-  @apply bg-background;
+  @apply bg-paper-2;
 }
 
 ::-webkit-scrollbar-thumb {
-  @apply bg-muted-foreground/30 rounded-full;
+  @apply bg-rule-2 rounded-none;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  @apply bg-muted-foreground/50;
-}
-
-/* Loading Skeleton */
-.skeleton {
-  @apply animate-pulse bg-muted rounded;
+  @apply bg-muted;
 }
 
 /* Text Selection */
 ::selection {
-  @apply bg-primary/30;
+  @apply bg-accent-ink text-white;
 }
 
 /* Focus Visible */
 *:focus-visible {
-  @apply outline-none ring-2 ring-ring ring-offset-2 ring-offset-background;
+  @apply outline-none ring-2 ring-accent ring-offset-2 ring-offset-paper;
 }
 
 /* Mark (highlighted text) */
 mark {
-  @apply bg-yellow-300 dark:bg-yellow-600 px-1 rounded;
+  @apply bg-yellow-300/50 dark:bg-yellow-800/50 px-1 rounded-sm;
 }
 
 /* Website-matched utilities */
-.font-mono {
-  font-family: 'JetBrains Mono', monospace;
+
+/* hairline rule grid background */
+.paper-grid {
+  background-image:
+    linear-gradient(to right, hsl(var(--ink) / 0.045) 1px, transparent 1px),
+    linear-gradient(to bottom, hsl(var(--ink) / 0.045) 1px, transparent 1px);
+  background-size: 80px 80px;
 }
 
-/* Blue Tinted Grid - strictly matching website */
-.bg-grid {
-  background-size: 40px 40px;
-  background-image: linear-gradient(to right, rgba(37, 99, 235, 0.05) 1px, transparent 1px),
-    linear-gradient(to bottom, rgba(37, 99, 235, 0.05) 1px, transparent 1px);
+/* sober link */
+.link-underline {
+  background-image: linear-gradient(currentColor, currentColor);
+  background-size: 100% 1px;
+  background-repeat: no-repeat;
+  background-position: 0 100%;
 }
 
-.tech-panel {
-  background: hsl(var(--card));
-  border: 1px solid hsl(var(--border));
-  box-shadow: 0 4px 6px -1px rgba(37, 99, 235, 0.05), 0 2px 4px -1px rgba(37, 99, 235, 0.03);
+/* row hover for clean lists */
+.row { 
+  border-top: 1px solid hsl(var(--rule)); 
+}
+.row:last-child { 
+  border-bottom: 1px solid hsl(var(--rule)); 
 }
 
-@keyframes shimmer {
-  100% {
-    transform: translateX(100%);
-  }
+/* terminal area */
+.terminal {
+  @apply font-mono;
+  background: #0d1320; 
+  color: #d6d3c8;
 }
 
-/* ===== GLASSMORPHISM DESIGN SYSTEM ===== */
-
-/* Glass Panel - Base translucent container */
-.glass-panel {
-  background: rgba(255, 255, 255, 0.02);
-  backdrop-filter: blur(10px) saturate(160%);
-  -webkit-backdrop-filter: blur(10px) saturate(160%);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-top: 1px solid rgba(255, 255, 255, 0.1); /* Subtle shine */
-  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.05); /* Inner glow */
-  border-radius: 12px;
+/* section number marks */
+.section-num {
+  @apply font-mono text-[11px] tracking-[0.08em] text-muted;
 }
 
-/* Glass Card - Elevated glass container with glow */
-.glass-card {
-  background: rgba(255, 255, 255, 0.03);
-  backdrop-filter: blur(16px) saturate(180%);
-  -webkit-backdrop-filter: blur(16px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-top: 1px solid rgba(255, 255, 255, 0.15); /* Subtle shine */
-  border-radius: var(--radius);
-  box-shadow:
-    0 4px 30px rgba(0, 0, 0, 0.2),
-    inset 0 0 20px rgba(255, 255, 255, 0.02);
-}
-
-/* Glass Card with hover glow effect */
-.glass-card-hover {
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-}
-.glass-card-hover:hover {
-  border-color: rgba(0, 242, 255, 0.3);
-  box-shadow:
-    0 8px 40px rgba(0, 0, 0, 0.3),
-    0 0 20px -5px rgba(0, 242, 255, 0.2),
-    inset 0 0 10px rgba(0, 242, 255, 0.05);
-  transform: translateY(-1px);
-}
-
-/* ===== SCI-FI ATMOSPHERE & ACCENTS ===== */
-
-/* Ambient Light Blobs */
-.bg-blob {
-  position: fixed;
-  width: 60vw;
-  height: 60vw;
-  filter: blur(140px);
-  opacity: 0.04;
-  z-index: -1;
-  pointer-events: none;
-  background: radial-gradient(circle, rgba(0, 242, 255, 0.8) 0%, transparent 70%);
-  animation: blob-float 20s infinite alternate ease-in-out;
-}
-
-.bg-blob-secondary {
-  background: radial-gradient(circle, rgba(37, 99, 235, 0.8) 0%, transparent 70%);
-  animation-delay: -5s;
-  animation-duration: 25s;
-}
-
-@keyframes blob-float {
-  0% { transform: translate(0, 0) scale(1); }
-  100% { transform: translate(10%, 10%) scale(1.1); }
-}
-
-/* Neon Text */
-.neon-text {
-  color: #00f2ff;
-  text-shadow: 0 0 10px rgba(0, 242, 255, 0.5);
-}
-
-/* Active Beam Border */
-.active-border {
-  border: 1px solid #00f2ff;
-  box-shadow: 0 0 15px rgba(0, 242, 255, 0.2), inset 0 0 5px rgba(0, 242, 255, 0.1);
-}
-
-/* Glow Effects */
-.glow-blue {
-  box-shadow: 0 0 30px -5px rgba(37, 99, 235, 0.4);
-}
-
-.glow-blue-subtle {
-  box-shadow: 0 0 20px -5px rgba(37, 99, 235, 0.2);
-}
-
-.glow-primary {
-  box-shadow: 0 0 30px -5px hsl(var(--primary) / 0.4);
-}
-
-/* Text glow for headings */
-.text-glow {
-  text-shadow: 0 0 20px hsl(var(--primary) / 0.5);
-}
-
-/* Border glow animation */
-@keyframes border-glow {
-  0%, 100% {
-    border-color: var(--glass-border);
-  }
-  50% {
-    border-color: var(--glass-glow);
-  }
-}
-
-.animate-border-glow {
-  animation: border-glow 3s ease-in-out infinite;
-}
-
-/* Pulse glow for status indicators */
-@keyframes pulse-glow {
-  0%, 100% {
-    box-shadow: 0 0 10px 0 hsl(var(--primary) / 0.3);
-  }
-  50% {
-    box-shadow: 0 0 20px 5px hsl(var(--primary) / 0.5);
-  }
-}
-
-.animate-pulse-glow {
-  animation: pulse-glow 2s ease-in-out infinite;
+/* Loading Skeleton */
+.skeleton {
+  @apply animate-pulse bg-rule-2 rounded-none;
 }
 
 /* Fade in up animation */
@@ -318,113 +165,4 @@ mark {
 
 .animate-fade-in-up {
   animation: fade-in-up 0.4s ease-out;
-}
-
-/* Gradient text utility */
-.gradient-text {
-  background: linear-gradient(135deg, hsl(var(--primary-light)), hsl(var(--primary)));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-/* Coming Soon badge styling */
-.badge-coming-soon {
-  @apply px-2 py-0.5 text-xs font-medium rounded-full;
-  background: linear-gradient(135deg, rgba(37, 99, 235, 0.2), rgba(59, 130, 246, 0.1));
-  border: 1px solid rgba(37, 99, 235, 0.3);
-  color: hsl(var(--primary-light));
-}
-
-/* Simulated/stub badge */
-.badge-simulated {
-  @apply px-2 py-0.5 text-xs font-medium rounded-full;
-  background: rgba(234, 179, 8, 0.15);
-  border: 1px solid rgba(234, 179, 8, 0.3);
-  color: rgb(234, 179, 8);
-}
-
-/* ===== CYAN GLOW ANIMATIONS ===== */
-
-/* Glow pulse for cyan accent */
-@keyframes glow-pulse-cyan {
-  0%, 100% { box-shadow: 0 0 15px 0 rgba(0, 212, 255, 0.3); }
-  50% { box-shadow: 0 0 30px 5px rgba(0, 212, 255, 0.5); }
-}
-
-.animate-glow-pulse-cyan {
-  animation: glow-pulse-cyan 2s ease-in-out infinite;
-}
-
-/* Cyan glow utilities */
-.glow-cyan {
-  box-shadow: 0 0 30px -5px rgba(0, 212, 255, 0.4);
-}
-
-.glow-cyan-subtle {
-  box-shadow: 0 0 20px -5px rgba(0, 212, 255, 0.2);
-}
-
-.glow-cyan-lg {
-  box-shadow: 0 0 40px -5px rgba(0, 212, 255, 0.5), 0 0 80px -20px rgba(0, 212, 255, 0.3);
-}
-
-/* Text glow cyan */
-.text-glow-cyan {
-  text-shadow: 0 0 20px rgba(0, 212, 255, 0.5);
-}
-
-/* Gradient text - cyan to green */
-.gradient-text-cyan {
-  background: linear-gradient(135deg, #00d4ff, #00ff88);
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-/* Surface utilities for new hierarchy */
-.bg-surface-1 {
-  background-color: hsl(var(--surface-1));
-}
-
-.bg-surface-2 {
-  background-color: hsl(var(--surface-2));
-}
-
-.bg-surface-3 {
-  background-color: hsl(var(--surface-3));
-}
-
-/* Glass panel with cyan border (variant) */
-.glass-panel-cyan {
-  background: rgba(0, 25, 40, 0.3);
-  backdrop-filter: blur(12px) saturate(150%);
-  -webkit-backdrop-filter: blur(12px) saturate(150%);
-  border: 1px solid rgba(0, 242, 255, 0.2);
-  box-shadow: 0 4px 30px rgba(0, 0, 0, 0.2), 0 0 40px -10px rgba(0, 242, 255, 0.15);
-}
-
-/* Search modal overlay */
-.search-modal-overlay {
-  background: rgba(0, 0, 0, 0.75);
-  backdrop-filter: blur(8px);
-  -webkit-backdrop-filter: blur(8px);
-}
-
-/* Cyan accent border gradient */
-.border-gradient-cyan {
-  position: relative;
-}
-
-.border-gradient-cyan::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  padding: 1px;
-  background: linear-gradient(180deg, rgba(0, 212, 255, 0.3), transparent);
-  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
-  -webkit-mask-composite: xor;
-  mask-composite: exclude;
-  pointer-events: none;
 }

--- a/screensearch-ui/src/pages/Dashboard.tsx
+++ b/screensearch-ui/src/pages/Dashboard.tsx
@@ -9,10 +9,10 @@ export function DashboardPage() {
     <div className="max-w-7xl mx-auto space-y-6 animate-fade-in-up">
       {/* Page Header */}
       <div className="space-y-2">
-        <h1 className="text-3xl font-bold tracking-tight gradient-text-cyan">
+        <h1 className="font-serif text-[34px] lg:text-[42px] leading-[1.08] tracking-[-0.01em] text-ink">
           ScreenSearch Intel
         </h1>
-        <p className="text-muted-foreground">
+        <p className="text-ink-2 text-[16px] leading-[1.6]">
           Your AI-powered productivity insights at a glance.
         </p>
       </div>

--- a/screensearch-ui/src/pages/Intelligence.tsx
+++ b/screensearch-ui/src/pages/Intelligence.tsx
@@ -5,10 +5,10 @@ export function IntelligencePage() {
     return (
         <div className="max-w-6xl mx-auto space-y-8 animate-in fade-in duration-500">
             <div className="space-y-2">
-                <h1 className="text-3xl font-bold tracking-tight bg-gradient-to-r from-primary to-purple-600 bg-clip-text text-transparent">
+                <h1 className="font-serif text-[34px] lg:text-[42px] leading-[1.08] tracking-[-0.01em] text-ink">
                     Intelligence
                 </h1>
-                <p className="text-muted-foreground">
+                <p className="text-ink-2 text-[16px] leading-[1.6]">
                     Generate insights and summaries from your ScreenSearch data using AI.
                 </p>
             </div>
@@ -17,9 +17,9 @@ export function IntelligencePage() {
                 <div className="space-y-6">
                     <AiSettings />
 
-                    <div className="bg-muted/30 p-4 rounded-lg text-sm text-muted-foreground">
+                    <div className="bg-paper-2 border border-rule p-4 rounded-none text-sm font-serif italic text-muted">
                         <p>
-                            <strong>Privacy Note:</strong> When generating reports, summaries of your screen metadata
+                            <strong className="font-sans font-bold">Privacy Note:</strong> When generating reports, summaries of your screen metadata
                             (app names, window titles, OCR text) will be sent to the configured AI provider.
                             Local providers (like Ollama) keep data on your device.
                         </p>

--- a/screensearch-ui/tailwind.config.js
+++ b/screensearch-ui/tailwind.config.js
@@ -19,17 +19,17 @@ export default {
       },
       colors: {
         // Core design system colors from screensearch-website
-        ink: "hsl(var(--ink))",
-        "ink-2": "hsl(var(--ink-2))",
-        muted: "hsl(var(--muted))",
-        rule: "hsl(var(--rule))",
-        "rule-2": "hsl(var(--rule-2))",
-        paper: "hsl(var(--paper))",
-        "paper-2": "hsl(var(--paper-2))",
-        accent: "hsl(var(--accent))",
-        "accent-ink": "hsl(var(--accent-ink))",
-        warn: "hsl(var(--warn))",
-        good: "hsl(var(--good))",
+        ink: "hsl(var(--ink) / <alpha-value>)",
+        "ink-2": "hsl(var(--ink-2) / <alpha-value>)",
+        muted: "hsl(var(--muted) / <alpha-value>)",
+        rule: "hsl(var(--rule) / <alpha-value>)",
+        "rule-2": "hsl(var(--rule-2) / <alpha-value>)",
+        paper: "hsl(var(--paper) / <alpha-value>)",
+        "paper-2": "hsl(var(--paper-2) / <alpha-value>)",
+        accent: "hsl(var(--accent) / <alpha-value>)",
+        "accent-ink": "hsl(var(--accent-ink) / <alpha-value>)",
+        warn: "hsl(var(--warn) / <alpha-value>)",
+        good: "hsl(var(--good) / <alpha-value>)",
         
         // Semantic mapping for existing UI components
         border: "hsl(var(--rule))",

--- a/screensearch-ui/tailwind.config.js
+++ b/screensearch-ui/tailwind.config.js
@@ -8,8 +8,9 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        display: ['Inter var', 'Inter', 'system-ui', 'sans-serif'],
-        mono: ['JetBrains Mono', 'Fira Code', 'monospace'],
+        sans: ['Geist', 'ui-sans-serif', 'system-ui', '-apple-system', 'sans-serif'],
+        serif: ['Newsreader', 'Iowan Old Style', 'Georgia', 'serif'],
+        mono: ['Geist Mono', 'ui-monospace', 'monospace'],
       },
       fontSize: {
         'display-lg': ['3rem', { lineHeight: '1.1', letterSpacing: '-0.02em' }],
@@ -17,67 +18,65 @@ export default {
         'title': ['1.5rem', { lineHeight: '1.3', fontWeight: '600' }],
       },
       colors: {
-        border: "hsl(var(--border))",
-        input: "hsl(var(--input))",
-        ring: "hsl(var(--ring))",
-        background: "hsl(var(--background))",
-        foreground: "hsl(var(--foreground))",
+        // Core design system colors from screensearch-website
+        ink: "hsl(var(--ink))",
+        "ink-2": "hsl(var(--ink-2))",
+        muted: "hsl(var(--muted))",
+        rule: "hsl(var(--rule))",
+        "rule-2": "hsl(var(--rule-2))",
+        paper: "hsl(var(--paper))",
+        "paper-2": "hsl(var(--paper-2))",
+        accent: "hsl(var(--accent))",
+        "accent-ink": "hsl(var(--accent-ink))",
+        warn: "hsl(var(--warn))",
+        good: "hsl(var(--good))",
+        
+        // Semantic mapping for existing UI components
+        border: "hsl(var(--rule))",
+        input: "hsl(var(--rule-2))",
+        ring: "hsl(var(--accent))",
+        background: "hsl(var(--paper))",
+        foreground: "hsl(var(--ink))",
         primary: {
-          DEFAULT: "hsl(var(--primary))",
-          light: "hsl(var(--primary-light))",
-          dark: "hsl(var(--primary-dark))",
-          foreground: "hsl(var(--primary-foreground))",
+          DEFAULT: "hsl(var(--accent-ink))",
+          foreground: "hsl(var(--paper))",
         },
         secondary: {
-          DEFAULT: "hsl(var(--secondary))",
-          foreground: "hsl(var(--secondary-foreground))",
+          DEFAULT: "hsl(var(--paper-2))",
+          foreground: "hsl(var(--ink))",
         },
         destructive: {
-          DEFAULT: "hsl(var(--destructive))",
-          foreground: "hsl(var(--destructive-foreground))",
-        },
-        muted: {
-          DEFAULT: "hsl(var(--muted))",
-          foreground: "hsl(var(--muted-foreground))",
-        },
-        accent: {
-          DEFAULT: "hsl(var(--accent))",
-          primary: "hsl(var(--accent-primary))",
-          glow: "hsl(var(--accent-glow))",
-          muted: "hsl(var(--accent-muted))",
-          foreground: "hsl(var(--accent-foreground))",
+          DEFAULT: "hsl(var(--warn))",
+          foreground: "hsl(var(--paper))",
         },
         card: {
-          DEFAULT: "hsl(var(--card))",
-          foreground: "hsl(var(--card-foreground))",
+          DEFAULT: "hsl(var(--paper))",
+          foreground: "hsl(var(--ink))",
         },
         surface: {
-          1: "hsl(var(--surface-1))",
-          2: "hsl(var(--surface-2))",
-          3: "hsl(var(--surface-3))",
-        },
-        // Glassmorphism colors
-        glass: {
-          bg: "var(--glass-bg)",
-          border: "var(--glass-border)",
-          glow: "var(--glass-glow)",
-        },
-        // Cyan accent for direct usage
-        cyan: {
-          DEFAULT: "#00d4ff",
-          glow: "#33e0ff",
-          muted: "#265a66",
+          1: "hsl(var(--paper))",
+          2: "hsl(var(--paper-2))",
+          3: "hsl(var(--rule))",
         },
       },
       borderRadius: {
-        lg: "var(--radius)",
-        md: "calc(var(--radius) - 2px)",
-        sm: "calc(var(--radius) - 4px)",
-        '2xl': '1rem',
-        '3xl': '1.5rem',
+        // Brutalist style uses sharp corners or very minimal radii
+        lg: "0",
+        md: "0",
+        sm: "0",
+        '2xl': '0',
+        '3xl': '0',
+        full: '9999px',
+      },
+      boxShadow: {
+        // Very subtle or hard shadows
+        sm: "0 1px 2px 0 rgba(0, 0, 0, 0.05)",
+        DEFAULT: "0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px -1px rgba(0, 0, 0, 0.1)",
+        md: "0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1)",
+        lg: "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)",
+        hard: "4px 4px 0px 0px rgba(0,0,0,1)",
       },
       keyframes: {
-        // Core UI animations - actively used
         "fade-in": {
           "0%": { opacity: "0" },
           "100%": { opacity: "1" },
@@ -90,53 +89,11 @@ export default {
           "0%": { opacity: "0", transform: "translateY(10px)" },
           "100%": { opacity: "1", transform: "translateY(0)" },
         },
-        "slide-up-fade": {
-          "0%": { opacity: "0", transform: "translateY(10px)" },
-          "100%": { opacity: "1", transform: "translateY(0)" },
-        },
-        "scale-in": {
-          "0%": { opacity: "0", transform: "scale(0.95)" },
-          "100%": { opacity: "1", transform: "scale(1)" },
-        },
-        // Glow effects - used in glass components
-        "pulse-glow": {
-          "0%, 100%": { boxShadow: "0 0 10px 0 rgba(0, 212, 255, 0.3)" },
-          "50%": { boxShadow: "0 0 20px 5px rgba(0, 212, 255, 0.5)" },
-        },
-        "glow-pulse": {
-          "0%, 100%": { boxShadow: "0 0 15px 0 rgba(0, 212, 255, 0.3)" },
-          "50%": { boxShadow: "0 0 30px 5px rgba(0, 212, 255, 0.5)" },
-        },
-        "border-glow": {
-          "0%, 100%": { borderColor: "hsl(var(--glass-border))" },
-          "50%": { borderColor: "var(--glass-glow)" },
-        },
-        // Modal animations
-        "modal-appear": {
-          "0%": { opacity: "0", transform: "scale(0.95) translateY(-20px)" },
-          "100%": { opacity: "1", transform: "scale(1) translateY(0)" },
-        },
-        "backdrop-appear": {
-          "0%": { opacity: "0" },
-          "100%": { opacity: "1" },
-        },
       },
       animation: {
-        "fade-in": "fade-in 0.3s ease-in-out",
-        "slide-in": "slide-in 0.3s ease-out",
-        "fade-in-up": "fade-in-up 0.4s ease-out",
-        "slide-up": "slide-up-fade 0.3s ease-out",
-        "scale-in": "scale-in 0.2s ease-out",
-        "pulse-glow": "pulse-glow 2s ease-in-out infinite",
-        "glow-pulse": "glow-pulse 2s ease-in-out infinite",
-        "border-glow": "border-glow 3s ease-in-out infinite",
-        "modal-appear": "modal-appear 0.3s cubic-bezier(0.16, 1, 0.3, 1)",
-        "backdrop-appear": "backdrop-appear 0.2s ease-out",
-      },
-      backdropBlur: {
-        xs: '2px',
-        xl: '24px',
-        '2xl': '40px',
+        "fade-in": "fade-in 0.2s ease-out",
+        "slide-in": "slide-in 0.2s ease-out",
+        "fade-in-up": "fade-in-up 0.3s ease-out",
       },
     },
   },


### PR DESCRIPTION
…ark mode## Changed
- **Brutalist / Minimalist Paper UI Redesign**: Overhauled the entire React frontend to match the print-media brutalist design of `screensearch-website`.
  - Replaced glassmorphism visual layout, translucent backdrops, radial gradients, glowing accents, and rounded corners with a flat, sharp, 90-degree corner design.
  - Implemented dynamic light and dark theme modes using custom HSL theme tokens (`bg-paper`, `text-ink`, `border-rule`).
  - Adopted newspaper-style typography: **Newsreader** (Serif) for headers and inputs, **Geist** (Sans) for UI copy, and **Geist Mono** (Monospace) for data metrics.
  - Redesigned `Sidebar.tsx`, `Timeline.tsx`, `FrameCard.tsx`, `SearchBar.tsx`, `Dashboard.tsx`, `Intelligence.tsx`, `AiSettings.tsx`, `SettingsPanel.tsx`, and `GlassCard.tsx` base components to utilize flat paper backgrounds, solid rule borders, and physical hover transforms instead of glows.
