### PR TITLE
feat(vision): on-device screen understanding via unified gemma-4 server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   download remains available as a fallback. `GET /api/ai/model/status` now lists
   discovered models via `available_models`.
 
+### Fixed
+- **Vision worker no longer risks a tight infinite loop / CPU pegging on a
+  failing frame.** Previously `fail_analysis_task` unlocked the task
+  (`locked_until = NULL`) without removing it, so the worker re-claimed and
+  re-failed the same task with zero delay — pegging a CPU core and flooding the
+  log. Failures now apply exponential backoff (1→2→4 min) and the task is dropped
+  from the queue after `MAX_ANALYSIS_ATTEMPTS` (3) tries; the frame stays marked
+  `failed` for manual retry.
+- **Frame-load and image-decode errors in the vision worker are now marked
+  failed instead of bubbling up.** A missing frame, corrupt screenshot, or
+  serialization error previously returned early via `?`, skipping
+  `fail_analysis_task` and leaving the task locked for 5 minutes only to fail
+  again. They are now logged, recorded as failed, and the worker continues. The
+  worker also cools down briefly after a failure.
+- **`get_vision_status` now does a single scan of `frames`** via conditional
+  aggregation instead of five sequential `COUNT(*)` round-trips.
+
 ### Removed
 - The Python sidecar (`sidecar/`), its PyInstaller packaging, and all sidecar
   process management, build steps, and bundling from `main.rs`, the build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **On-device vision (screen understanding) via the unified local llama-server.**
+  When vision is enabled with the `local` provider, the same auto-managed
+  llama.cpp server that answers AI reports is now launched with `--mmproj` so a
+  single Gemma&nbsp;4 model serves **both** text generation and image analysis
+  (Option B — unify on gemma-4). The vision worker analyzes frames against this
+  local server's OpenAI-compatible `/v1/chat/completions` endpoint (no external
+  Ollama/OpenAI needed) and populates each frame's `description`,
+  `visible_text`, `activity_type`, `app_hint`, and `confidence`.
+  - **Model/projector auto-discovery**: `resolve_mmproj_for()` pairs a model with
+    the correct `*mmproj*.gguf` projector beside it by size signature (e.g. an
+    E4B model gets the E4B projector, a 12B model the 12B projector; a text-only
+    model like Qwen3.5 is never mis-paired). `resolve_vision_model()` picks the
+    unified vision model, preferring a Gemma&nbsp;4 **E4B**. Drop a Gemma&nbsp;4
+    GGUF and its `*mmproj*.gguf` into `.models/`.
+  - **Enqueue is on-demand + throttled**: `POST /api/vision/analyze/:frame_id`
+    queues a single frame at high priority; the worker also trickles in a small
+    batch (4) of recent un-analyzed frames per idle cycle to keep GPU load
+    bounded. `GET /api/vision/status` reports per-status frame counts and queue
+    depth.
+  - The unified server is rebuilt automatically when vision is toggled (it
+    switches the loaded model to the vision model + projector and back).
+  - Files: `screensearch-llm/src/{server.rs,download.rs}`,
+    `screensearch-api/src/{state.rs,server.rs,routes.rs,handlers/vision.rs,
+    workers/vision_worker.rs}`, `screensearch-db/src/{queries.rs,models.rs}`.
 - **Bundled `onnxruntime.dll` (ONNX Runtime 1.24.2, x64) in all Windows
   artifacts**, so a fresh install has working semantic search out of the box. The
   in-process fastembed engine loads ONNX Runtime dynamically and looks for the DLL

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@
 - [*] **Continuous Screen Capture** — Configurable intervals (2-5 seconds) with multi-monitor support
 - [*] **OCR Text Extraction** — Native Windows OCR (WinRT) running in-process with confidence and bounding boxes
 - [*] **AI-Powered Intelligence** — Generate insights from your screen history using local LLMs (Ollama, LM Studio) or cloud providers (OpenAI)
+- [*] **On-Device Vision** — Optional screen understanding: a unified local Gemma 4 model (llama.cpp `--mmproj`) describes each screenshot, reads on-screen text from the image, and classifies activity — entirely on-device (or via an external vision provider). See [docs/vision.md](docs/vision.md)
 - [*] **Hybrid Search** — Fuses FTS5 and sqlite-vec retrieval via Reciprocal Rank Fusion, with optional cross-encoder reranking
 - [*] **Smart Search** — Conversational AI answers with context from your screen history
-- [*] **REST API** — 27 endpoints for search, automation, and tag management on localhost:3131
+- [*] **REST API** — endpoints for search, vision, automation, and tag management on localhost:3131
 - [*] **UI Automation** — Programmatic control of Windows applications via accessibility APIs
 - [*] **System Tray** — unobtrusive background operation with quick access menu
 - [*] **Privacy Controls** — Exclude sensitive applications, pause on screen lock
@@ -343,10 +344,12 @@ screensearch/
 ├── screensearch-capture/       # Capture + native Windows OCR (in-process)
 ├── screensearch-db/            # SQLite, FTS5, sqlite-vec, migrations
 ├── screensearch-embeddings/    # In-process fastembed (EmbeddingGemma-300M)
-├── screensearch-llm/           # Manages external llama.cpp answer-generation server
+├── screensearch-llm/           # Manages external llama.cpp server (text + vision via --mmproj)
+├── screensearch-vision/        # Vision provider client (screen understanding)
 ├── screensearch-api/           # REST API server (Axum framework)
 │   ├── src/routes.rs          # API endpoint definitions
-│   └── src/handlers/          # Search, embeddings, RAG, generation
+│   ├── src/handlers/          # Search, embeddings, RAG, generation, vision
+│   └── src/workers/           # Background embedding + vision workers
 ├── screensearch-automation/    # Windows UI automation engine
 ├── evaluation/                 # Versioned retrieval quality cases
 ├── screensearch-ui/            # Modern React web dashboard

--- a/docs/CODE_NAVIGATION.md
+++ b/docs/CODE_NAVIGATION.md
@@ -49,8 +49,20 @@
 | Grounded answer endpoint | `screensearch-api/src/handlers/generate.rs` |
 | Search modes | `screensearch-api/src/handlers/search.rs` |
 | Report generation endpoints | `screensearch-api/src/handlers/ai.rs` |
-| Generation provider client | `screensearch-vision/src/client.rs` |
+| Generation / vision provider client | `screensearch-vision/src/client.rs` |
 | Bundled local generation runtime | `screensearch-llm/` |
+| Unified server selection (text + vision) | `screensearch-api/src/state.rs` (`get_llama_server`) |
+
+## Vision (Screen Understanding)
+
+| Concern | File |
+|---|---|
+| `--mmproj` flag and server config | `screensearch-llm/src/server.rs` |
+| Model/projector discovery | `screensearch-llm/src/download.rs` (`resolve_mmproj_for`, `resolve_vision_model`) |
+| Vision worker (queue consumer) | `screensearch-api/src/workers/vision_worker.rs` |
+| Vision endpoints (analyze, status) | `screensearch-api/src/handlers/vision.rs` |
+| Queue and status queries | `screensearch-db/src/queries.rs` (`enqueue_frame_for_analysis`, `get_unanalyzed_frame_ids`, `get_vision_status`) |
+| `vision_*` settings columns | `screensearch-db/src/migrations.rs` |
 
 ## Frontend
 

--- a/docs/PROJECT_INDEX.md
+++ b/docs/PROJECT_INDEX.md
@@ -18,6 +18,7 @@ grounded answers and reports, and exposes Windows automation APIs.
 | Reranking | Optional bge-reranker-v2-m3 (fastembed), off by default |
 | Citations | Stable `[frame:<id>]` identifiers |
 | Optional generation | Auto-discovered local GGUF via llama.cpp, Ollama-compatible, OpenAI-compatible |
+| Optional vision | On-device screen understanding via the unified local llama.cpp server (`--mmproj`, Gemma 4), or an external vision provider |
 
 ## Entry Points
 
@@ -29,6 +30,8 @@ grounded answers and reports, and exposes Windows automation APIs.
 | OCR | `screensearch-capture/src/ocr_provider.rs` |
 | Embeddings | `screensearch-embeddings/src/engine.rs` |
 | Generation runtime | `screensearch-llm/` |
+| Vision worker | `screensearch-api/src/workers/vision_worker.rs` |
+| Vision client | `screensearch-vision/src/client.rs` |
 | Frontend | `screensearch-ui/src/main.tsx` |
 | Installer | `installer/screensearch.iss` |
 
@@ -43,6 +46,7 @@ grounded answers and reports, and exposes Windows automation APIs.
 | `docs/developer-guide.md` | Development, testing, release |
 | `docs/quick-reference.md` | Commands and active contracts |
 | `docs/ai-quality-stack.md` | Model contract and evaluation |
+| `docs/vision.md` | On-device vision (screen understanding) setup and API |
 | `docs/security.md` | Privacy and security boundaries |
 | `docs/CODE_NAVIGATION.md` | File-level routing |
 
@@ -51,9 +55,12 @@ grounded answers and reports, and exposes Windows automation APIs.
 `config.toml` controls startup services such as capture, OCR provider,
 database, retention, and embedding worker defaults.
 
-The SQLite `settings` row controls runtime capture settings and optional
-generation-provider settings. Existing `vision_*` database names configure
-generation only.
+The SQLite `settings` row controls runtime capture settings, the optional
+generation provider, and the optional vision pipeline. The `vision_*` columns
+(`vision_enabled`, `vision_provider`, `vision_model`, `vision_endpoint`,
+`vision_api_key`) now configure on-device (or external) screenshot analysis;
+with `vision_provider = "local"` the unified llama.cpp server is used for both
+generation and vision.
 
 ## Generated And External Data
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -258,6 +258,41 @@ Generates a report over a time range:
 Legacy route name retained for compatibility. It tests the configured
 generation provider; it does not test OCR or embedding retrieval.
 
+## Vision (Screen Understanding)
+
+On-device screenshot analysis. When vision is enabled with the `local` provider
+(see `POST /settings/`), the unified auto-managed llama-server is launched with
+`--mmproj` so a single Gemma&nbsp;4 model serves both text and image questions;
+analysis populates each frame's `description`, `visible_text`, `activity_type`,
+`app_hint`, and `confidence`. Drop a Gemma&nbsp;4 GGUF **and** its
+`*mmproj*.gguf` projector into `.models/`.
+
+### `POST /vision/analyze/:frame_id`
+
+Enqueue a single frame for vision analysis on demand (high priority — jumps
+ahead of the background trickle). The worker performs the analysis
+asynchronously.
+
+```bash
+curl -X POST "http://127.0.0.1:3131/api/vision/analyze/123"
+# -> {"success":true,"frame_id":123,"queue_id":7,"already_queued":false}
+```
+
+Returns `404` if the frame does not exist; `queue_id` is `0` (and
+`already_queued` is `true`) if the frame was already queued.
+
+### `GET /vision/status`
+
+Aggregate analysis status: configured provider/model plus per-status frame
+counts and queue depth.
+
+```bash
+curl "http://127.0.0.1:3131/api/vision/status"
+# -> {"enabled":1,"provider":"local","model":"gemma-4-E4B...",
+#     "total_frames":1024,"completed":300,"pending":4,"processing":1,
+#     "failed":0,"queue_depth":5}
+```
+
 ## Download Progress
 
 ### `GET /downloads/status`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,6 +179,26 @@ or reranking. Local generation keeps grounded context on-device. Remote
 generation sends the selected context, app names, and window titles to the
 configured provider.
 
+### Unified Local Vision
+
+When vision is enabled with the `local` provider, the same managed
+`llama.cpp` server is launched with `--mmproj` so one Gemma&nbsp;4 model serves
+both text generation and image analysis (one process, one model in VRAM).
+`resolve_vision_model` selects the unified vision model (preferring a
+Gemma&nbsp;4 E4B) and `resolve_mmproj_for` pairs it with the matching
+`*mmproj*.gguf` projector found beside it (matched by size signature, so a
+text-only model such as Qwen3.5 is never mis-paired). `AppState::get_llama_server`
+rebuilds the server when vision is toggled, swapping the loaded model/projector.
+
+The vision worker (`screensearch-api/src/workers/vision_worker.rs`) consumes the
+`analysis_queue` and calls the local server's OpenAI-compatible vision endpoint.
+Frames are enqueued **on demand** (`POST /api/vision/analyze/:frame_id`, high
+priority) and as a **throttled** background trickle of recent un-analyzed frames,
+bounding GPU load. Results are written back to each frame (`description`,
+`visible_text`, `activity_type`, `app_hint`, `confidence`). With external
+providers (Ollama / OpenAI-compatible), the worker targets the configured
+endpoint instead and no local server is started.
+
 ## Runtime Status
 
 `GET /api/embeddings/status` exposes:

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -103,8 +103,8 @@ Do not reintroduce in-memory full-vector scans or synthetic hash embeddings.
 
 ## Generation Development
 
-Generation is independent from retrieval. Existing database field names use
-`vision_*`, but the UI describes them as answer-generation settings.
+Generation is independent from retrieval. The `vision_*` database fields
+configure both the answer-generation provider and the vision pipeline.
 
 Supported runtimes:
 
@@ -119,6 +119,33 @@ Supported runtimes:
 
 The local model-management routes belong to generation only. They are not the
 embedding-engine status.
+
+## Vision Development
+
+Vision analyzes screenshot pixels and writes `description`, `visible_text`,
+`activity_type`, `app_hint`, and `confidence` onto frames. It is off by default
+and shares the `vision_*` settings.
+
+- **Local provider = unified server.** `AppState::get_llama_server`
+  (`screensearch-api/src/state.rs`) is vision-aware: when vision is enabled with
+  `vision_provider = "local"`, it runs the single llama.cpp server with
+  `--mmproj` so one Gemma 4 model serves both text and images, and it rebuilds
+  the server when vision toggles. Model/projector selection lives in
+  `screensearch-llm/src/download.rs` (`resolve_vision_model`,
+  `resolve_mmproj_for`, `discover_vision_models`); `--mmproj` emission and the
+  `mmproj_path` config field are in `screensearch-llm/src/server.rs`.
+- **Worker.** `screensearch-api/src/workers/vision_worker.rs` consumes
+  `analysis_queue`, calls the provider via `screensearch-vision` (OpenAI-compat
+  vision path for `local`), and writes results back. It takes `Arc<AppState>` via
+  `ApiServer::start_vision_worker`.
+- **Enqueue.** On demand (`POST /api/vision/analyze/:frame_id`) plus a throttled
+  background trickle (`DatabaseManager::get_unanalyzed_frame_ids`, batch 4).
+  `GET /api/vision/status` reports counts.
+- **Frames default to `analysis_status = 'pending'`** but are not auto-queued;
+  the trickle query treats anything not in `('completed','processing','failed')`
+  and not already queued as needing analysis.
+
+See `docs/vision.md` for the full guide.
 
 ## Local Linux Build
 

--- a/docs/embedded-llm.md
+++ b/docs/embedded-llm.md
@@ -123,7 +123,7 @@ pub struct LlmConfig {
     pub model_path: Option<PathBuf>,    // Auto-detected if None
     pub temperature: f32,                // Default: 0.7 (range: 0.0-2.0)
     pub max_tokens: usize,               // Default: 2048
-    pub context_length: usize,           // Default: 8192 (up to 256k supported)
+    pub context_length: usize,           // Default: 16384 (up to 256k supported)
     pub threads: usize,                  // Default: 0 (auto-detect CPU cores)
     pub use_gpu: bool,                   // Default: true (Vulkan acceleration)
     pub top_p: f32,                      // Default: 0.95 (nucleus sampling)
@@ -327,9 +327,18 @@ llama-server \
   --port <port> \
   --host 127.0.0.1 \
   -c <context_length> \
-  -ngl 99 \           # GPU layers (if use_gpu=true)
-  -t <threads>        # CPU threads (if specified)
+  --jinja \                  # use the model's embedded chat template (reasoning models)
+  --mmproj <projector> \     # only when LlamaServerConfig.mmproj_path is set (vision)
+  -ngl 99 \                  # GPU layers (if use_gpu=true)
+  -t <threads>               # CPU threads (if specified)
 ```
+
+`LlamaServerConfig.mmproj_path` is `None` for a text-only server. When set (vision
+enabled with the local provider), the server loads the multimodal projector so the
+**same** process serves both text generation and image (`image_url`) requests —
+ScreenSearch runs one unified Gemma 4 model rather than two servers. The API layer
+selects the model/projector and rebuilds the server when vision is toggled; the
+vision worker consumes the analysis queue. See `docs/vision.md`.
 
 ### 5.8 Port Fallback System
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,9 +78,10 @@ The API build script rebuilds changed frontend sources automatically.
 - `[embeddings]`;
 - `[api]`.
 
-Runtime settings in SQLite control capture state, retention, exclusions, and
-the optional generation provider. The legacy `vision_*` field names refer to
-generation, not OCR or embedding retrieval.
+Runtime settings in SQLite control capture state, retention, exclusions, the
+optional generation provider, and the optional vision pipeline. The `vision_*`
+field names configure generation and on-device/external screenshot analysis (not
+OCR or embedding retrieval). See `docs/vision.md`.
 
 ## Troubleshooting
 

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -60,18 +60,28 @@ curl -X POST "http://127.0.0.1:3131/api/generate" \
 Sources are returned as frame IDs. Context sent to the generation LLM is
 marked with `[frame:<id>]`.
 
-## Generation Provider
+## Generation And Vision Provider
 
-Generation settings are stored through `/api/settings/`. They do not control
-OCR or retrieval.
+Generation and vision settings are stored through `/api/settings/`. They do not
+control OCR or retrieval.
 
-Supported `vision_provider` values:
+Supported `vision_provider` values (shared by generation and vision):
 
 | Value | Runtime |
 |---|---|
-| `local` | Bundled llama.cpp server (auto-discovers `*.gguf`; Ministral-3B default) |
+| `local` | Bundled llama.cpp server (auto-discovers `*.gguf`; Ministral-3B default). For vision it loads a Gemma 4 model + `--mmproj` and serves both text and images. |
 | `ollama` | Ollama-compatible server |
 | `openai` | OpenAI-compatible endpoint |
+
+### Vision endpoints
+
+| Method | Path |
+|---|---|
+| `POST` | `/api/vision/analyze/:frame_id` |
+| `GET`  | `/api/vision/status` |
+
+Vision is off by default; enable via `vision_enabled=1`. On-demand enqueue plus a
+throttled background trickle. See `docs/vision.md`.
 
 ## Configuration
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -32,11 +32,19 @@ The application can make outbound requests for:
 
 - first-use Hugging Face model downloads (embedding and optional reranker);
 - bundled generation-model and llama-server downloads;
-- optional remote OpenAI-compatible generation.
+- optional remote OpenAI-compatible generation;
+- optional remote vision analysis (when `vision_provider` is `ollama`/`openai`).
 
 OCR, embeddings, sqlite-vec search, and reranking remain local. When remote
 generation is configured, selected OCR context and frame metadata leave the
 machine.
+
+Vision analysis runs **on-device** with `vision_provider = "local"` (image
+bytes never leave the machine — the bundled llama.cpp server analyzes them). With
+an external vision provider, the **screenshot image** (base64 JPEG), app name,
+and window title for each analyzed frame are sent to the configured endpoint —
+this is the only path that transmits raw pixels off the machine. Vision is off by
+default. See `docs/vision.md`.
 
 ## In-Process Inference
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -103,6 +103,26 @@ With a remote provider, the selected OCR passages and frame metadata used for
 generation leave the machine. OCR, embeddings, vector search, and reranking
 remain local.
 
+### Vision (Screen Understanding)
+
+Vision analysis is optional and **off by default**. When enabled, ScreenSearch
+looks at the *image* of each screenshot (not just its OCR text) and records a
+short description, the prominent on-screen text, an activity type, and a
+confidence score for each frame.
+
+- **Bundled local model (on-device)**: drop a **Gemma 4** model **and** its
+  `*mmproj*.gguf` projector into `.models/`, then enable vision with the *local*
+  provider. ScreenSearch reuses the same llama.cpp server as answer generation,
+  loading the projector so one model handles both — image bytes never leave the
+  machine.
+- **Ollama / OpenAI-compatible**: point vision at an external vision model. The
+  screenshot, app name, and window title for each analyzed frame are sent to that
+  provider.
+
+Frames are analyzed on demand and as a throttled background trickle, so enabling
+vision gradually works through your history without flooding the GPU. Turn vision
+off to stop it. See `docs/vision.md` for setup, model selection, and the API.
+
 ## Search Modes
 
 ### Keyword

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,148 @@
+# Vision (Screen Understanding)
+
+ScreenSearch can analyze the *pixels* of each captured screenshot — not just its
+OCR text — to produce a short natural-language description, the prominent
+on-screen text, an activity classification, and a confidence score. This is
+optional and **off by default**.
+
+Vision results are written back onto each frame and are visible through the
+frames API (`description`, `visible_text`, `activity_type`, `app_hint`,
+`confidence`).
+
+## How it works
+
+When vision is enabled with the **local** provider, ScreenSearch does **not**
+start a second model server. Instead it reuses the same auto-managed `llama.cpp`
+server that answers AI reports, launching it with `--mmproj` so a single
+**Gemma 4** model serves *both* text generation and image analysis. This keeps
+one model in VRAM and avoids running two servers (Option B — "unify on
+gemma-4").
+
+```
+Capture → frames (analysis_status='pending')
+                 │
+   on-demand  ───┤  POST /api/vision/analyze/:frame_id        (priority 10)
+   throttled  ───┘  background trickle of recent un-analyzed frames (batch 4)
+                 │
+         analysis_queue ──> vision worker (vision_worker.rs)
+                 │                 │
+                 │      OpenAI-compatible /v1/chat/completions (image_url)
+                 │                 │
+        unified llama.cpp server (gemma-4 + --mmproj)  ◄── also serves AI reports
+                 │
+   frame.description / visible_text_json / activity_type / app_hint / confidence
+```
+
+The server is rebuilt automatically when vision is toggled: enabling vision
+switches the loaded model to the vision model + projector; disabling it switches
+back to the first discovered text GGUF.
+
+### Model and projector selection (local provider)
+
+- `resolve_vision_model()` chooses the unified model. It first tries to match the
+  `vision_model` setting against a discovered model filename; otherwise it
+  prefers a **Gemma 4 E4B** model; otherwise it uses the first vision-capable
+  model found.
+- `resolve_mmproj_for()` pairs that model with the correct `*mmproj*.gguf`
+  projector sitting beside it, matched by **size signature** (e.g. an `E4B` model
+  gets the `E4B` projector, a `12B` model the `12B` projector). A text-only model
+  such as Qwen3.5 has no matching projector and is never mis-paired.
+- A model is "vision-capable" only if a matching projector is found next to it.
+
+## Setup (local, on-device)
+
+1. **Drop a Gemma 4 model and its projector into `.models/`** (repo root, next to
+   the executable, or the app models directory). You need both files:
+   - a model GGUF, e.g. `gemma-4-E4B-it-qat-UD-Q4_K_XL.gguf`;
+   - its projector, e.g. `gemma-4-E4B-it-mmproj.gguf`.
+2. **Download the bundled llama-server** if you have not already (Settings →
+   AI → Download Server, or `POST /api/ai/server/download`). Vision requires the
+   pinned build; an outdated build is treated as missing.
+3. **Enable vision**: Settings → Vision → toggle on, provider = *Bundled local
+   model*. Equivalent API call:
+
+   ```bash
+   curl -X POST "http://127.0.0.1:3131/api/settings" \
+     -H 'content-type: application/json' \
+     -d '{"capture_interval":5,"monitors":"[]",
+          "excluded_apps":"[]","is_paused":0,"retention_days":30,
+          "vision_enabled":1,"vision_provider":"local",
+          "vision_model":"gemma-4-E4B","vision_endpoint":"http://127.0.0.1:31130",
+          "vision_api_key":null}'
+   ```
+
+4. The worker starts the unified server (first request loads the model; this can
+   take 20–60 s) and begins analyzing frames.
+
+> **Tip — model quality.** If `vision_model` does not match a specific file, the
+> first Gemma 4 **E4B** by filename order is used, which may be a low-quality
+> quant (e.g. `Q2_K_XL`). Set `vision_model` to a substring of the exact file you
+> want (e.g. `Q4_K_XL`) to pin a higher-quality quant. The same model is then
+> also used for AI reports while vision is enabled.
+
+## Setup (external provider)
+
+Set `vision_provider` to `ollama` or `openai` (any OpenAI-compatible vision
+endpoint) and fill in `vision_endpoint`, `vision_model`, and `vision_api_key`.
+No local server is started; the worker calls the configured endpoint. Screenshots
+(as base64 JPEG), app names, and window titles are sent to that provider.
+
+## Enqueue behavior — on-demand and throttled
+
+Vision is **not** run on every frame automatically. Frames are analyzed:
+
+- **On demand** — `POST /api/vision/analyze/:frame_id` queues a single frame at
+  high priority (jumps the line).
+- **Throttled trickle** — while vision is enabled, the worker enqueues a small
+  batch (4) of recent un-analyzed frames per idle cycle, newest first, so it
+  works through history without flooding the GPU. The throttle bounds the *rate*,
+  not the total: over time it will analyze all eligible history. Disable vision
+  to stop it.
+
+A captured frame starts at `analysis_status = 'pending'`. "Eligible" means any
+frame whose status is not `completed`, `processing`, or `failed` and that is not
+already queued.
+
+## API
+
+| Method | Path | Purpose |
+|---|---|---|
+| `POST` | `/api/vision/analyze/:frame_id` | Enqueue one frame (on demand) |
+| `GET`  | `/api/vision/status` | Provider/model, per-status counts, queue depth |
+| `POST` | `/api/test-vision` | Test the configured vision/generation provider |
+
+See `docs/api-reference.md` for request/response details.
+
+## Where things live
+
+| Concern | File |
+|---|---|
+| `--mmproj` flag, server config | `screensearch-llm/src/server.rs` |
+| Model/projector discovery | `screensearch-llm/src/download.rs` (`resolve_mmproj_for`, `resolve_vision_model`, `discover_vision_models`) |
+| Unified server selection | `screensearch-api/src/state.rs` (`get_llama_server`, `resolve_server_models`) |
+| Vision worker | `screensearch-api/src/workers/vision_worker.rs` |
+| Vision client (HTTP) | `screensearch-vision/src/client.rs` |
+| Endpoints | `screensearch-api/src/handlers/vision.rs`, `routes.rs` |
+| Queue + status queries | `screensearch-db/src/queries.rs` (`enqueue_frame_for_analysis`, `claim_analysis_task`, `get_unanalyzed_frame_ids`, `get_vision_status`) |
+| Settings columns | `screensearch-db/src/migrations.rs` (`vision_*`) |
+
+## Privacy
+
+With the **local** provider, vision runs entirely on-device — image bytes never
+leave the machine. With an **external** provider, the screenshot, app name, and
+window title for each analyzed frame are sent to the configured endpoint. See
+`docs/security.md`.
+
+## Troubleshooting
+
+- **Nothing gets analyzed / `queue_depth` stays 0**: confirm `vision_enabled=1`
+  and (local) that llama-server is downloaded and current. The worker logs
+  `Vision enabled (local) but llama-server is not downloaded/current` when the
+  binary is missing/outdated.
+- **`no vision model + mmproj projector was found`**: you have a model but no
+  matching `*mmproj*.gguf` beside it (or only a text-only model like Qwen3.5).
+  Add the projector for your Gemma 4 model.
+- **First analysis is slow**: the unified server loads the model on the first
+  request (20–60 s). Subsequent frames are much faster.
+- **Results are low quality**: pin a higher-quality quant via `vision_model`
+  (see the tip above).

--- a/screensearch-api/src/handlers/ai.rs
+++ b/screensearch-api/src/handlers/ai.rs
@@ -362,8 +362,12 @@ OUTPUT FORMAT (Markdown):
 
         // Get the endpoint from the running server (handles port fallback)
         let endpoint = format!("{}/v1", server.endpoint().await);
-        // Report the actual GGUF the server resolved (not a hardcoded name).
-        let model_name = screensearch_llm::resolve_model_path()
+        // Report the actual GGUF the server loaded (the unified server may run a
+        // vision model when vision is enabled), not a hardcoded name.
+        let model_name = server
+            .current_models()
+            .await
+            .0
             .file_stem()
             .and_then(|s| s.to_str())
             .map(|s| s.to_string())

--- a/screensearch-api/src/handlers/mod.rs
+++ b/screensearch-api/src/handlers/mod.rs
@@ -17,3 +17,5 @@ pub mod reranker;
 pub use generate::*;
 pub mod downloads;
 pub use downloads::*;
+pub mod vision;
+pub use vision::*;

--- a/screensearch-api/src/handlers/vision.rs
+++ b/screensearch-api/src/handlers/vision.rs
@@ -1,0 +1,71 @@
+//! Vision analysis endpoint handlers
+//!
+//! On-demand frame analysis enqueue plus an aggregate status view. The actual
+//! analysis is performed asynchronously by the vision worker
+//! (`crate::workers::vision_worker`), which drives the unified local
+//! llama-server (with `--mmproj`) or an external provider.
+
+use crate::error::{AppError, Result};
+use crate::state::AppState;
+use axum::extract::{Path, State};
+use axum::Json;
+use std::sync::Arc;
+use tracing::{debug, info};
+
+/// Priority given to user-requested (on-demand) analysis so it jumps ahead of
+/// the background trickle (priority 0).
+const ON_DEMAND_PRIORITY: i32 = 10;
+
+/// POST /api/vision/analyze/:frame_id
+///
+/// Enqueue a single frame for vision analysis on demand. Returns the queue id
+/// (0 if the frame was already queued).
+pub async fn analyze_frame(
+    State(state): State<Arc<AppState>>,
+    Path(frame_id): Path<i64>,
+) -> Result<Json<serde_json::Value>> {
+    debug!("On-demand vision analysis requested for frame {}", frame_id);
+
+    // Make sure the frame exists before queueing.
+    let frame = state
+        .db
+        .get_frame(frame_id)
+        .await
+        .map_err(AppError::Database)?;
+    if frame.is_none() {
+        return Err(AppError::NotFound(format!("Frame {} not found", frame_id)));
+    }
+
+    let queue_id = state
+        .db
+        .enqueue_frame_for_analysis(frame_id, ON_DEMAND_PRIORITY)
+        .await
+        .map_err(AppError::Database)?;
+
+    info!(
+        "Frame {} enqueued for vision analysis (queue_id={})",
+        frame_id, queue_id
+    );
+
+    Ok(Json(serde_json::json!({
+        "success": true,
+        "frame_id": frame_id,
+        "queue_id": queue_id,
+        "already_queued": queue_id == 0,
+    })))
+}
+
+/// GET /api/vision/status
+///
+/// Aggregate vision-analysis status: per-status frame counts, queue depth, and
+/// the configured vision provider/model.
+pub async fn get_vision_status(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<screensearch_db::models::VisionStatus>> {
+    let status = state
+        .db
+        .get_vision_status()
+        .await
+        .map_err(AppError::Database)?;
+    Ok(Json(status))
+}

--- a/screensearch-api/src/routes.rs
+++ b/screensearch-api/src/routes.rs
@@ -29,6 +29,8 @@ pub fn build_router(state: Arc<AppState>) -> Router {
         .nest("/ai", ai_routes())
         // Embeddings endpoints (RAG)
         .nest("/embeddings", embeddings_routes())
+        // Vision analysis endpoints
+        .nest("/vision", vision_routes())
         // Download progress endpoints
         .nest("/downloads", downloads_routes())
         // RAG Answer generation
@@ -180,6 +182,13 @@ fn embeddings_routes() -> Router<Arc<AppState>> {
         .route("/models/prepare", post(handlers::prepare_quality_models))
         .route("/generate", post(handlers::generate_embeddings))
         .route("/enable", post(handlers::toggle_embeddings))
+}
+
+/// Vision analysis routes
+fn vision_routes() -> Router<Arc<AppState>> {
+    Router::new()
+        .route("/status", get(handlers::get_vision_status))
+        .route("/analyze/:frame_id", post(handlers::analyze_frame))
 }
 
 /// Download progress routes

--- a/screensearch-api/src/server.rs
+++ b/screensearch-api/src/server.rs
@@ -178,6 +178,14 @@ impl ApiServer {
         Ok(())
     }
 
+    /// Start the background vision analysis worker.
+    ///
+    /// The worker shares the API server's `AppState` so it can drive the unified
+    /// auto-managed llama-server (started with `--mmproj`) for local vision.
+    pub fn start_vision_worker(&self) {
+        crate::workers::vision_worker::spawn_vision_worker(Arc::clone(&self.state));
+    }
+
     /// Synchronize the startup configuration with the runtime metadata toggle.
     pub async fn set_embeddings_enabled(&self, enabled: bool) -> anyhow::Result<()> {
         self.state

--- a/screensearch-api/src/state.rs
+++ b/screensearch-api/src/state.rs
@@ -5,6 +5,7 @@ use screensearch_db::DatabaseManager;
 use screensearch_embeddings::{EmbeddingEngine, EMBEDDING_DIM};
 use screensearch_llm::LlamaServer;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
@@ -137,35 +138,61 @@ impl AppState {
         Ok(engine_arc)
     }
 
-    /// Get or initialize the LlamaServer
-    pub async fn get_llama_server(&self) -> Result<Arc<LlamaServer>, String> {
-        use screensearch_llm::{resolve_model_path, LlamaServerConfig};
+    /// Resolve which model (and optional vision projector) the unified
+    /// llama-server should run.
+    ///
+    /// When vision is enabled with the local provider and a vision-capable
+    /// model + projector is available, the single server runs that model with
+    /// its `mmproj` so it serves both text generation and vision (Option B:
+    /// unify on gemma-4). Otherwise it runs the first discovered GGUF text-only.
+    async fn resolve_server_models(&self) -> (PathBuf, Option<PathBuf>) {
+        use screensearch_llm::{resolve_model_path, resolve_vision_model};
 
-        // Check if already initialized
-        {
-            let guard = self.llama_server.read().await;
-            if let Some(server) = guard.as_ref() {
+        if let Ok(settings) = self.db.get_settings().await {
+            if settings.vision_enabled != 0 && settings.vision_provider == "local" {
+                if let Some((model, mmproj)) = resolve_vision_model(&settings.vision_model) {
+                    return (model, Some(mmproj));
+                }
+            }
+        }
+
+        (resolve_model_path(), None)
+    }
+
+    /// Get or initialize the LlamaServer.
+    ///
+    /// The server is (re)built when the desired model/projector differs from
+    /// the cached one — e.g. when vision is toggled, which switches the unified
+    /// server to a gemma-4 model loaded with `--mmproj`. The whole compare/
+    /// rebuild runs under the write lock so concurrent callers (AI reports and
+    /// the vision worker) converge on a single server instance.
+    pub async fn get_llama_server(&self) -> Result<Arc<LlamaServer>, String> {
+        use screensearch_llm::LlamaServerConfig;
+
+        let (model_path, mmproj_path) = self.resolve_server_models().await;
+
+        let mut guard = self.llama_server.write().await;
+
+        // Reuse the cached server when it already targets the same model + projector.
+        if let Some(server) = guard.as_ref() {
+            if server.current_models().await == (model_path.clone(), mmproj_path.clone()) {
                 return Ok(Arc::clone(server));
             }
         }
 
-        // Use the first user-provided GGUF discovered in `.models/` (etc.),
-        // falling back to the downloadable default path.
-        let model_path = resolve_model_path();
+        // Desired model/projector changed: stop the stale server and rebuild.
+        if let Some(previous) = guard.take() {
+            previous.shutdown().await;
+        }
 
         let config = LlamaServerConfig {
             model_path,
+            mmproj_path,
             ..Default::default()
         };
 
-        let server = LlamaServer::new(config);
-        let server_arc = Arc::new(server);
-
-        // Store it
-        {
-            let mut guard = self.llama_server.write().await;
-            *guard = Some(Arc::clone(&server_arc));
-        }
+        let server_arc = Arc::new(LlamaServer::new(config));
+        *guard = Some(Arc::clone(&server_arc));
 
         Ok(server_arc)
     }

--- a/screensearch-api/src/workers/vision_worker.rs
+++ b/screensearch-api/src/workers/vision_worker.rs
@@ -1,5 +1,5 @@
 use crate::state::AppState;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use screensearch_db::{models::FrameAnalysisUpdate, DatabaseManager};
 use screensearch_vision::{client::OllamaClient, VisionModel};
 use std::sync::Arc;
@@ -145,10 +145,16 @@ pub fn spawn_vision_worker(state: Arc<AppState>) {
 
             if let Some(c) = &client {
                 match process_next_item(&db, c).await {
-                    Ok(true) => {
-                        // Did work; loop immediately to drain the queue.
+                    Ok(WorkOutcome::Completed) => {
+                        // Did useful work; loop immediately to drain the queue.
                     }
-                    Ok(false) => {
+                    Ok(WorkOutcome::Failed) => {
+                        // The task was marked failed (and either dropped or backed
+                        // off in the DB). Cool down briefly so a run of failing
+                        // frames can't peg a CPU core or flood the log.
+                        sleep(Duration::from_secs(2)).await;
+                    }
+                    Ok(WorkOutcome::Idle) => {
                         // Queue empty: throttled trickle of recent un-analyzed frames.
                         match auto_enqueue(&db).await {
                             Ok(n) if n > 0 => {
@@ -192,64 +198,115 @@ async fn auto_enqueue(db: &DatabaseManager) -> Result<usize> {
     Ok(enqueued)
 }
 
-async fn process_next_item(db: &DatabaseManager, client: &Arc<dyn VisionModel>) -> Result<bool> {
+/// Outcome of a single worker iteration, so the loop can pace itself: drain
+/// immediately after useful work, cool down after a failure, and idle when the
+/// queue is empty.
+enum WorkOutcome {
+    /// A task was analyzed successfully.
+    Completed,
+    /// A task was claimed but failed; it has been marked failed in the DB.
+    Failed,
+    /// No task was available to claim.
+    Idle,
+}
+
+async fn process_next_item(
+    db: &DatabaseManager,
+    client: &Arc<dyn VisionModel>,
+) -> Result<WorkOutcome> {
     // 1. Claim task
-    let task = db.claim_analysis_task("worker-1").await?;
+    let task = match db.claim_analysis_task("worker-1").await? {
+        Some(task) => task,
+        None => return Ok(WorkOutcome::Idle),
+    };
 
-    if let Some(task) = task {
-        debug!(
-            "Processing analysis task id: {} for frame: {}",
-            task.id, task.frame_id
-        );
+    debug!(
+        "Processing analysis task id: {} for frame: {}",
+        task.id, task.frame_id
+    );
 
-        // 2. Fetch frame data (image path)
-        let frame = db
-            .get_frame(task.frame_id)
-            .await?
-            .context("Frame not found for analysis task")?;
-
-        // 3. Load image
-        let image = image::open(&frame.file_path)
-            .context(format!("Failed to open image at {}", frame.file_path))?;
-
-        // 4. Analyze
-        let context = format!(
-            "App: {}, Window: {}",
-            frame.active_process.unwrap_or_default(),
-            frame.active_window.unwrap_or_default()
-        );
-
-        let started = Instant::now();
-        match client.analyze(&image, &context).await {
-            Ok(analysis) => {
-                // 5. Update success
-                let update = FrameAnalysisUpdate {
-                    description: Some(analysis.description),
-                    visible_text_json: Some(serde_json::to_string(&analysis.visible_text)?),
-                    activity_type: Some(analysis.activity_type),
-                    app_hint: analysis.app_hint,
-                    confidence: Some(analysis.confidence),
-                    analysis_time_ms: Some(started.elapsed().as_millis() as i64),
-                };
-
-                db.complete_analysis_task(task.id, task.frame_id, update)
-                    .await?;
-                info!(
-                    "Analysis completed for frame {} in {} ms",
-                    task.frame_id,
-                    started.elapsed().as_millis()
-                );
-            }
-            Err(e) => {
-                // 6. Update failure
-                error!("Analysis failed for frame {}: {}", task.frame_id, e);
-                db.fail_analysis_task(task.id, task.frame_id, e.to_string())
-                    .await?;
-            }
+    // 2. Fetch frame data (image path). A missing frame / DB error must NOT
+    //    bubble up with `?`: that would skip `fail_analysis_task`, leaving the
+    //    task locked for 5 minutes only to fail again. Mark it failed instead so
+    //    the queue keeps moving (and the task is eventually dropped after
+    //    MAX_ANALYSIS_ATTEMPTS).
+    let frame = match db.get_frame(task.frame_id).await {
+        Ok(Some(frame)) => frame,
+        Ok(None) => {
+            let msg = "Frame not found for analysis task";
+            warn!("{} (frame {})", msg, task.frame_id);
+            db.fail_analysis_task(task.id, task.frame_id, msg.to_string())
+                .await?;
+            return Ok(WorkOutcome::Failed);
         }
+        Err(e) => {
+            error!("Failed to load frame {}: {}", task.frame_id, e);
+            db.fail_analysis_task(task.id, task.frame_id, e.to_string())
+                .await?;
+            return Ok(WorkOutcome::Failed);
+        }
+    };
 
-        Ok(true)
-    } else {
-        Ok(false)
+    // 3. Load image. Same rule: a missing/corrupt screenshot is marked failed,
+    //    never bubbled up.
+    let image = match image::open(&frame.file_path) {
+        Ok(img) => img,
+        Err(e) => {
+            error!("Failed to open image at {}: {}", frame.file_path, e);
+            db.fail_analysis_task(task.id, task.frame_id, e.to_string())
+                .await?;
+            return Ok(WorkOutcome::Failed);
+        }
+    };
+
+    // 4. Analyze
+    let context = format!(
+        "App: {}, Window: {}",
+        frame.active_process.unwrap_or_default(),
+        frame.active_window.unwrap_or_default()
+    );
+
+    let started = Instant::now();
+    match client.analyze(&image, &context).await {
+        Ok(analysis) => {
+            // 5. Update success
+            let visible_text_json = match serde_json::to_string(&analysis.visible_text) {
+                Ok(json) => Some(json),
+                Err(e) => {
+                    error!(
+                        "Failed to serialize visible_text for frame {}: {}",
+                        task.frame_id, e
+                    );
+                    db.fail_analysis_task(task.id, task.frame_id, e.to_string())
+                        .await?;
+                    return Ok(WorkOutcome::Failed);
+                }
+            };
+
+            let update = FrameAnalysisUpdate {
+                description: Some(analysis.description),
+                visible_text_json,
+                activity_type: Some(analysis.activity_type),
+                app_hint: analysis.app_hint,
+                confidence: Some(analysis.confidence),
+                analysis_time_ms: Some(started.elapsed().as_millis() as i64),
+            };
+
+            db.complete_analysis_task(task.id, task.frame_id, update)
+                .await?;
+            info!(
+                "Analysis completed for frame {} in {} ms",
+                task.frame_id,
+                started.elapsed().as_millis()
+            );
+            Ok(WorkOutcome::Completed)
+        }
+        Err(e) => {
+            // 6. Update failure
+            error!("Analysis failed for frame {}: {}", task.frame_id, e);
+            db.fail_analysis_task(task.id, task.frame_id, e.to_string())
+                .await?;
+            Ok(WorkOutcome::Failed)
+        }
     }
 }

--- a/screensearch-api/src/workers/vision_worker.rs
+++ b/screensearch-api/src/workers/vision_worker.rs
@@ -1,19 +1,35 @@
+use crate::state::AppState;
 use anyhow::{Context, Result};
 use screensearch_db::{models::FrameAnalysisUpdate, DatabaseManager};
 use screensearch_vision::{client::OllamaClient, VisionModel};
 use std::sync::Arc;
-use tokio::time::{sleep, Duration};
-use tracing::{debug, error, info};
+use tokio::time::{sleep, Duration, Instant};
+use tracing::{debug, error, info, warn};
 
-/// Spawn the vision analysis worker
-pub fn spawn_vision_worker(db: Arc<DatabaseManager>) {
+/// How many recent un-analyzed frames the throttled auto-enqueuer pulls in per
+/// idle cycle. Small so vision analysis trickles through history (newest first)
+/// instead of flooding the GPU. On-demand requests via `POST /api/vision/analyze`
+/// get a higher priority and jump the queue.
+const AUTO_ENQUEUE_BATCH: i64 = 4;
+
+/// Spawn the vision analysis worker.
+///
+/// When the local provider is selected, the worker drives the same auto-managed
+/// llama-server used for AI reports — started with `--mmproj` so a single
+/// gemma-4 model serves both text and vision (Option B). For external providers
+/// (ollama / OpenAI-compatible) it talks to the configured endpoint.
+pub fn spawn_vision_worker(state: Arc<AppState>) {
     tokio::spawn(async move {
         info!("Vision worker started");
+
+        let db = Arc::clone(&state.db);
 
         let mut current_provider = String::new();
         let mut current_model = String::new();
         let mut current_endpoint = String::new();
         let mut client: Option<Arc<dyn VisionModel>> = None;
+        // Throttle the "llama-server not downloaded" warning so it doesn't spam.
+        let mut last_missing_warn: Option<Instant> = None;
 
         loop {
             // Fetch settings
@@ -32,54 +48,122 @@ pub fn spawn_vision_worker(db: Arc<DatabaseManager>) {
                 continue;
             }
 
-            // Check if config changed
-            let config_changed = settings.vision_provider != current_provider
-                || settings.vision_model != current_model
-                || settings.vision_endpoint != current_endpoint
+            // Resolve the effective provider / model / endpoint for this cycle.
+            // For the local provider we drive the unified llama-server.
+            let (provider, model, endpoint, api_key) = if settings.vision_provider == "local" {
+                // The vision-capable model is served by the local llama-server,
+                // which must be downloaded and current.
+                let bin_dir = screensearch_llm::get_bin_dir();
+                if !screensearch_llm::llama_server_up_to_date(&bin_dir) {
+                    let should_warn = last_missing_warn
+                        .map(|t| t.elapsed() > Duration::from_secs(60))
+                        .unwrap_or(true);
+                    if should_warn {
+                        warn!(
+                            "Vision enabled (local) but llama-server is not downloaded/current. \
+                             Download it from Settings → AI → Download Server."
+                        );
+                        last_missing_warn = Some(Instant::now());
+                    }
+                    sleep(Duration::from_secs(30)).await;
+                    continue;
+                }
+
+                // Get (rebuilding if needed) the unified server and ensure it is
+                // running with the vision projector loaded.
+                let server = match state.get_llama_server().await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        error!("Failed to initialize llama-server for vision: {}", e);
+                        sleep(Duration::from_secs(10)).await;
+                        continue;
+                    }
+                };
+
+                let (model_path, mmproj_path) = server.current_models().await;
+                if mmproj_path.is_none() {
+                    let should_warn = last_missing_warn
+                        .map(|t| t.elapsed() > Duration::from_secs(60))
+                        .unwrap_or(true);
+                    if should_warn {
+                        warn!(
+                            "Vision enabled (local) but no vision model + mmproj projector was \
+                             found in .models/. Drop a gemma-4 model and its *mmproj*.gguf there."
+                        );
+                        last_missing_warn = Some(Instant::now());
+                    }
+                    sleep(Duration::from_secs(30)).await;
+                    continue;
+                }
+
+                if let Err(e) = server.ensure_started().await {
+                    error!("Failed to start local llama-server for vision: {}", e);
+                    sleep(Duration::from_secs(10)).await;
+                    continue;
+                }
+
+                let endpoint = server.endpoint().await;
+                let model = model_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "local".to_string());
+
+                // provider "local" routes OllamaClient through its OpenAI-compatible
+                // (image_url) path, which llama.cpp serves at /v1/chat/completions.
+                ("local".to_string(), model, endpoint, None)
+            } else {
+                (
+                    settings.vision_provider.clone(),
+                    settings.vision_model.clone(),
+                    settings.vision_endpoint.clone(),
+                    settings.vision_api_key.clone(),
+                )
+            };
+
+            // (Re)build the client when the effective config changed.
+            let config_changed = provider != current_provider
+                || model != current_model
+                || endpoint != current_endpoint
                 || client.is_none();
 
             if config_changed {
                 info!(
-                    "Vision settings changed, updating client: provider={}, model={}",
-                    settings.vision_provider, settings.vision_model
+                    "Vision client (re)configured: provider={}, model={}, endpoint={}",
+                    provider, model, endpoint
                 );
-
-                // create new client
-                let new_client: Arc<dyn VisionModel> = if settings.vision_provider == "ollama" {
-                    Arc::new(OllamaClient::new(
-                        settings.vision_endpoint.clone(),
-                        settings.vision_model.clone(),
-                        settings.vision_api_key.clone(),
-                        settings.vision_provider.clone(),
-                    ))
-                } else {
-                    // TODO: Local model support
-                    // For now default to Ollama if unknown or "local" unimplemented
-                    if settings.vision_provider == "local" {
-                        // error!("Local model not fully implemented, falling back to Ollama stub or error");
-                        // For now we don't have LocalClient implemented fully, so we might want to warn
-                        // But let's stick to Ollama for the prototype as verified.
-                    }
-
-                    Arc::new(OllamaClient::new(
-                        settings.vision_endpoint.clone(),
-                        settings.vision_model.clone(),
-                        settings.vision_api_key.clone(),
-                        settings.vision_provider.clone(),
-                    ))
-                };
-
-                client = Some(new_client);
-                current_provider = settings.vision_provider;
-                current_model = settings.vision_model;
-                current_endpoint = settings.vision_endpoint;
+                client = Some(Arc::new(OllamaClient::new(
+                    endpoint.clone(),
+                    model.clone(),
+                    api_key,
+                    provider.clone(),
+                )));
+                current_provider = provider;
+                current_model = model;
+                current_endpoint = endpoint;
             }
 
             if let Some(c) = &client {
                 match process_next_item(&db, c).await {
-                    Ok(did_work) => {
-                        if !did_work {
-                            sleep(Duration::from_secs(1)).await;
+                    Ok(true) => {
+                        // Did work; loop immediately to drain the queue.
+                    }
+                    Ok(false) => {
+                        // Queue empty: throttled trickle of recent un-analyzed frames.
+                        match auto_enqueue(&db).await {
+                            Ok(n) if n > 0 => {
+                                debug!("Auto-enqueued {} frame(s) for vision analysis", n);
+                                // Small pause to keep GPU load bounded between batches.
+                                sleep(Duration::from_millis(500)).await;
+                            }
+                            Ok(_) => {
+                                // Nothing left to analyze.
+                                sleep(Duration::from_secs(5)).await;
+                            }
+                            Err(e) => {
+                                error!("Auto-enqueue failed: {}", e);
+                                sleep(Duration::from_secs(5)).await;
+                            }
                         }
                     }
                     Err(e) => {
@@ -92,6 +176,20 @@ pub fn spawn_vision_worker(db: Arc<DatabaseManager>) {
             }
         }
     });
+}
+
+/// Enqueue a throttled batch of recent un-analyzed frames. Returns how many
+/// were newly queued.
+async fn auto_enqueue(db: &DatabaseManager) -> Result<usize> {
+    let ids = db.get_unanalyzed_frame_ids(AUTO_ENQUEUE_BATCH).await?;
+    let mut enqueued = 0;
+    for id in ids {
+        // Priority 0 = background trickle (on-demand requests use higher priority).
+        if db.enqueue_frame_for_analysis(id, 0).await? > 0 {
+            enqueued += 1;
+        }
+    }
+    Ok(enqueued)
 }
 
 async fn process_next_item(db: &DatabaseManager, client: &Arc<dyn VisionModel>) -> Result<bool> {
@@ -112,7 +210,7 @@ async fn process_next_item(db: &DatabaseManager, client: &Arc<dyn VisionModel>) 
 
         // 3. Load image
         let image = image::open(&frame.file_path)
-            .context(format!("Failed to open image at {}", frame.file_path))?; // map_err?
+            .context(format!("Failed to open image at {}", frame.file_path))?;
 
         // 4. Analyze
         let context = format!(
@@ -121,6 +219,7 @@ async fn process_next_item(db: &DatabaseManager, client: &Arc<dyn VisionModel>) 
             frame.active_window.unwrap_or_default()
         );
 
+        let started = Instant::now();
         match client.analyze(&image, &context).await {
             Ok(analysis) => {
                 // 5. Update success
@@ -130,12 +229,16 @@ async fn process_next_item(db: &DatabaseManager, client: &Arc<dyn VisionModel>) 
                     activity_type: Some(analysis.activity_type),
                     app_hint: analysis.app_hint,
                     confidence: Some(analysis.confidence),
-                    analysis_time_ms: Some(0), // Measure time?
+                    analysis_time_ms: Some(started.elapsed().as_millis() as i64),
                 };
 
                 db.complete_analysis_task(task.id, task.frame_id, update)
                     .await?;
-                info!("Analysis completed for frame {}", task.frame_id);
+                info!(
+                    "Analysis completed for frame {} in {} ms",
+                    task.frame_id,
+                    started.elapsed().as_millis()
+                );
             }
             Err(e) => {
                 // 6. Update failure

--- a/screensearch-db/src/models.rs
+++ b/screensearch-db/src/models.rs
@@ -332,6 +332,29 @@ pub struct AnalysisQueueItem {
     pub last_error: Option<String>,
 }
 
+/// Aggregate status of vision (frame) analysis across the database.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct VisionStatus {
+    /// Whether vision analysis is enabled in settings (0/1).
+    pub enabled: i64,
+    /// The configured vision provider (e.g. "local", "ollama").
+    pub provider: String,
+    /// The configured vision model name.
+    pub model: String,
+    /// Total frames in the database.
+    pub total_frames: i64,
+    /// Frames whose analysis completed.
+    pub completed: i64,
+    /// Frames queued or claimed for analysis.
+    pub pending: i64,
+    /// Frames currently being analyzed.
+    pub processing: i64,
+    /// Frames whose last analysis attempt failed.
+    pub failed: i64,
+    /// Number of items waiting in the analysis queue.
+    pub queue_depth: i64,
+}
+
 /// Request bundle for testing vision connection
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestVisionRequest {

--- a/screensearch-db/src/queries.rs
+++ b/screensearch-db/src/queries.rs
@@ -8,6 +8,11 @@ use crate::{DatabaseManager, Result, EMBEDDING_DIM};
 use chrono::{DateTime, Utc};
 use sqlx::Row;
 
+/// Maximum number of times a vision analysis task is tried before it is dropped
+/// from the queue. Prevents a permanently-failing frame (e.g. a deleted
+/// screenshot) from being retried forever. See [`DatabaseManager::fail_analysis_task`].
+const MAX_ANALYSIS_ATTEMPTS: i64 = 3;
+
 impl DatabaseManager {
     // ===== Video Chunk Operations =====
 
@@ -1179,20 +1184,27 @@ impl DatabaseManager {
     pub async fn get_vision_status(&self) -> Result<crate::models::VisionStatus> {
         let settings = self.get_settings().await?;
 
-        let total_frames = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM frames")
-            .fetch_one(self.pool())
-            .await?;
+        // Single scan of `frames` via conditional aggregation instead of five
+        // separate COUNT(*) round-trips.
+        let row = sqlx::query(
+            r#"
+            SELECT
+                COUNT(*) AS total,
+                COALESCE(SUM(CASE WHEN analysis_status = 'completed' THEN 1 ELSE 0 END), 0) AS completed,
+                COALESCE(SUM(CASE WHEN analysis_status = 'pending' THEN 1 ELSE 0 END), 0) AS pending,
+                COALESCE(SUM(CASE WHEN analysis_status = 'processing' THEN 1 ELSE 0 END), 0) AS processing,
+                COALESCE(SUM(CASE WHEN analysis_status = 'failed' THEN 1 ELSE 0 END), 0) AS failed
+            FROM frames
+            "#,
+        )
+        .fetch_one(self.pool())
+        .await?;
 
-        let count_status = |status: &str| {
-            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM frames WHERE analysis_status = ?")
-                .bind(status.to_string())
-                .fetch_one(self.pool())
-        };
-
-        let completed = count_status("completed").await?;
-        let pending = count_status("pending").await?;
-        let processing = count_status("processing").await?;
-        let failed = count_status("failed").await?;
+        let total_frames: i64 = row.get("total");
+        let completed: i64 = row.get("completed");
+        let pending: i64 = row.get("pending");
+        let processing: i64 = row.get("processing");
+        let failed: i64 = row.get("failed");
 
         let queue_depth = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM analysis_queue")
             .fetch_one(self.pool())
@@ -1298,7 +1310,17 @@ impl DatabaseManager {
         Ok(())
     }
 
-    /// Mark analysis as failed
+    /// Mark analysis as failed.
+    ///
+    /// Critically, this never leaves a claimable task with `locked_until = NULL`:
+    /// doing so would let the worker re-claim the same failing task on the very
+    /// next loop iteration with no delay, pegging a CPU core and flooding the log.
+    /// Instead we either:
+    /// - **give up** and delete the task from the queue once `attempts` reaches
+    ///   [`MAX_ANALYSIS_ATTEMPTS`] (the frame is already marked `'failed'`, so the
+    ///   user can see the error and re-enqueue manually), or
+    /// - **back off** by setting `locked_until` to an exponentially growing delay
+    ///   so a transient failure is retried later instead of in a tight loop.
     pub async fn fail_analysis_task(
         &self,
         queue_id: i64,
@@ -1316,14 +1338,35 @@ impl DatabaseManager {
         .execute(&mut *tx)
         .await?;
 
-        // Update queue item - unlock and record error, or delete if max attempts?
-        // Let's just release lock and let retry handle it, unless max attempts reached
-        // Doing simpler logic: release lock immediately so it can be retried later or inspect manually
-        sqlx::query("UPDATE analysis_queue SET locked_until = NULL, last_error = ? WHERE id = ?")
+        // `attempts` was already incremented when the task was claimed, so it
+        // reflects how many times this task has been tried.
+        let attempts =
+            sqlx::query_scalar::<_, i64>("SELECT attempts FROM analysis_queue WHERE id = ?")
+                .bind(queue_id)
+                .fetch_optional(&mut *tx)
+                .await?
+                .unwrap_or(MAX_ANALYSIS_ATTEMPTS);
+
+        if attempts >= MAX_ANALYSIS_ATTEMPTS {
+            // Exhausted retries: drop it so it can never re-clog the queue.
+            sqlx::query("DELETE FROM analysis_queue WHERE id = ?")
+                .bind(queue_id)
+                .execute(&mut *tx)
+                .await?;
+        } else {
+            // Exponential backoff: 1, 2, 4 minutes ... keyed off the attempt count.
+            let backoff_minutes = 1i64 << (attempts.max(1) - 1).min(6);
+            sqlx::query(
+                "UPDATE analysis_queue \
+                 SET locked_until = datetime('now', '+' || ? || ' minutes'), last_error = ? \
+                 WHERE id = ?",
+            )
+            .bind(backoff_minutes)
             .bind(&error)
             .bind(queue_id)
             .execute(&mut *tx)
             .await?;
+        }
 
         tx.commit().await?;
         Ok(())

--- a/screensearch-db/src/queries.rs
+++ b/screensearch-db/src/queries.rs
@@ -1148,6 +1148,69 @@ impl DatabaseManager {
         Ok(result.last_insert_rowid())
     }
 
+    /// Recent frames that still need vision analysis and are not already queued.
+    ///
+    /// Captured frames default to `analysis_status = 'pending'` but are not
+    /// auto-queued, so "needs analysis" is any frame whose status is not a
+    /// terminal/in-flight state (`completed`/`processing`/`failed`) and that is
+    /// not already in the queue. Returned newest-first so a throttled background
+    /// enqueuer works through the most relevant (recent) history first.
+    pub async fn get_unanalyzed_frame_ids(&self, limit: i64) -> Result<Vec<i64>> {
+        let ids = sqlx::query_scalar::<_, i64>(
+            r#"
+            SELECT f.id
+            FROM frames f
+            WHERE (f.analysis_status IS NULL
+                   OR f.analysis_status NOT IN ('completed', 'processing', 'failed'))
+              AND NOT EXISTS (SELECT 1 FROM analysis_queue q WHERE q.frame_id = f.id)
+            ORDER BY f.id DESC
+            LIMIT ?
+            "#,
+        )
+        .bind(limit)
+        .fetch_all(self.pool())
+        .await?;
+
+        Ok(ids)
+    }
+
+    /// Aggregate status of vision analysis (counts by frame analysis_status plus
+    /// the current queue depth and the configured vision settings).
+    pub async fn get_vision_status(&self) -> Result<crate::models::VisionStatus> {
+        let settings = self.get_settings().await?;
+
+        let total_frames = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM frames")
+            .fetch_one(self.pool())
+            .await?;
+
+        let count_status = |status: &str| {
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM frames WHERE analysis_status = ?")
+                .bind(status.to_string())
+                .fetch_one(self.pool())
+        };
+
+        let completed = count_status("completed").await?;
+        let pending = count_status("pending").await?;
+        let processing = count_status("processing").await?;
+        let failed = count_status("failed").await?;
+
+        let queue_depth = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM analysis_queue")
+            .fetch_one(self.pool())
+            .await?;
+
+        Ok(crate::models::VisionStatus {
+            enabled: settings.vision_enabled,
+            provider: settings.vision_provider,
+            model: settings.vision_model,
+            total_frames,
+            completed,
+            pending,
+            processing,
+            failed,
+            queue_depth,
+        })
+    }
+
     /// Get pending analysis tasks (locks them implicitly by return, caller must process)
     /// Ideally we should use a transaction to lock rows, but SQLite is single-writer.
     /// We can use 'locked_until' to implement a soft lock.

--- a/screensearch-db/tests/integration_tests.rs
+++ b/screensearch-db/tests/integration_tests.rs
@@ -694,3 +694,107 @@ async fn test_pagination() {
 
     db.close().await;
 }
+
+/// Regression test for the vision worker infinite-loop bug: a failed analysis
+/// task must NOT be left immediately re-claimable (which would peg a CPU core
+/// and flood the log). After a failure the task is backed off, so the very next
+/// claim returns nothing.
+#[tokio::test]
+async fn test_failed_analysis_task_is_not_immediately_reclaimable() {
+    let (db, _path) = create_test_db().await;
+
+    let frame_id = db
+        .insert_frame(create_test_frame(Utc::now(), "code", "Will fail"))
+        .await
+        .unwrap();
+
+    db.enqueue_frame_for_analysis(frame_id, 0).await.unwrap();
+
+    // Claim and fail the task.
+    let task = db
+        .claim_analysis_task("worker-1")
+        .await
+        .unwrap()
+        .expect("a task should be claimable");
+    assert_eq!(task.frame_id, frame_id);
+
+    db.fail_analysis_task(task.id, frame_id, "boom".to_string())
+        .await
+        .unwrap();
+
+    // The task is backed off, not unlocked: the next claim must return None
+    // instead of the same task. This is the core of the infinite-loop fix.
+    let next = db.claim_analysis_task("worker-1").await.unwrap();
+    assert!(
+        next.is_none(),
+        "a just-failed task must not be immediately re-claimable"
+    );
+
+    // It is still in the queue (one attempt < MAX_ANALYSIS_ATTEMPTS) and the
+    // frame is marked failed.
+    let status = db.get_vision_status().await.unwrap();
+    assert_eq!(status.failed, 1);
+    assert_eq!(status.queue_depth, 1);
+
+    db.close().await;
+}
+
+/// Verify the consolidated conditional-aggregation `get_vision_status` query
+/// reports correct per-status counts.
+#[tokio::test]
+async fn test_vision_status_counts_by_analysis_status() {
+    use screensearch_db::models::FrameAnalysisUpdate;
+
+    let (db, _path) = create_test_db().await;
+
+    // One frame analyzed successfully -> completed.
+    let completed_id = db
+        .insert_frame(create_test_frame(Utc::now(), "code", "Done"))
+        .await
+        .unwrap();
+    db.enqueue_frame_for_analysis(completed_id, 0)
+        .await
+        .unwrap();
+    let task = db.claim_analysis_task("w").await.unwrap().unwrap();
+    db.complete_analysis_task(
+        task.id,
+        completed_id,
+        FrameAnalysisUpdate {
+            description: Some("a window".to_string()),
+            visible_text_json: Some("[]".to_string()),
+            activity_type: Some("coding".to_string()),
+            app_hint: None,
+            confidence: Some(0.9),
+            analysis_time_ms: Some(42),
+        },
+    )
+    .await
+    .unwrap();
+
+    // One frame failed.
+    let failed_id = db
+        .insert_frame(create_test_frame(Utc::now(), "code", "Bad"))
+        .await
+        .unwrap();
+    db.enqueue_frame_for_analysis(failed_id, 0).await.unwrap();
+    let task = db.claim_analysis_task("w").await.unwrap().unwrap();
+    db.fail_analysis_task(task.id, failed_id, "nope".to_string())
+        .await
+        .unwrap();
+
+    // One frame still pending (enqueued, never claimed).
+    let pending_id = db
+        .insert_frame(create_test_frame(Utc::now(), "code", "Later"))
+        .await
+        .unwrap();
+    db.enqueue_frame_for_analysis(pending_id, 0).await.unwrap();
+
+    let status = db.get_vision_status().await.unwrap();
+    assert_eq!(status.total_frames, 3);
+    assert_eq!(status.completed, 1);
+    assert_eq!(status.failed, 1);
+    assert_eq!(status.pending, 1);
+    assert_eq!(status.processing, 0);
+
+    db.close().await;
+}

--- a/screensearch-llm/src/download.rs
+++ b/screensearch-llm/src/download.rs
@@ -311,6 +311,168 @@ pub fn resolve_model_path() -> PathBuf {
     get_model_path(&get_models_dir())
 }
 
+// ============================================================
+// Vision (multimodal projector) discovery
+// ============================================================
+
+/// Whether `token` looks like a model size marker such as `4b`, `12b`, `27b`,
+/// or `e4b` / `e2b` (an optional single-letter prefix, one or more digits, then
+/// a trailing `b`). Used to pair a model with the right `mmproj` projector when
+/// several projectors of different sizes sit in the same directory.
+fn is_size_token(token: &str) -> bool {
+    if token.len() < 2 || token.len() > 4 || !token.ends_with('b') {
+        return false;
+    }
+    let core = &token[..token.len() - 1];
+    // Drop an optional single leading letter (e.g. the `e` in `e4b`).
+    let digits = core
+        .strip_prefix(|c: char| c.is_ascii_alphabetic())
+        .unwrap_or(core);
+    !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Extract the first size signature (e.g. `e4b`, `12b`) from a (lowercased)
+/// filename stem, if any. Tokens are split on non-alphanumeric characters.
+fn size_signature(stem_lower: &str) -> Option<String> {
+    stem_lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .find(|tok| is_size_token(tok))
+        .map(|tok| tok.to_string())
+}
+
+/// Count of shared tokens between two (lowercased) stems.
+fn token_overlap(a_lower: &str, b_lower: &str) -> usize {
+    let a: std::collections::HashSet<&str> = a_lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .collect();
+    b_lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .filter(|t| !t.is_empty())
+        .filter(|t| a.contains(t))
+        .count()
+}
+
+/// Whether a GGUF filename is a multimodal projector (its name contains
+/// `mmproj`, the llama.cpp convention).
+fn is_mmproj_file(path: &Path) -> bool {
+    let is_gguf = path
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("gguf"));
+    let named = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| n.to_ascii_lowercase().contains("mmproj"));
+    path.is_file() && is_gguf && named
+}
+
+/// Find the multimodal projector (`mmproj` GGUF) that pairs with `model_path`,
+/// if one sits beside it.
+///
+/// llama.cpp needs `--mmproj <projector>` to enable vision for models like
+/// Gemma 4. A directory may hold several projectors (e.g. one for E4B and one
+/// for 12B), so we match on the model's size signature; if the model has a
+/// size signature but no projector matches it, we return `None` rather than
+/// guessing (a text-only model like Qwen3.5 must not be paired with a Gemma
+/// projector).
+pub fn resolve_mmproj_for(model_path: &Path) -> Option<PathBuf> {
+    // A projector is never its own projector.
+    if is_mmproj_file(model_path) {
+        return None;
+    }
+    let dir = model_path.parent()?;
+    let model_stem = model_path.file_stem()?.to_str()?.to_ascii_lowercase();
+
+    let mut candidates: Vec<PathBuf> = std::fs::read_dir(dir)
+        .ok()?
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| is_mmproj_file(p))
+        .collect();
+    if candidates.is_empty() {
+        return None;
+    }
+    candidates.sort();
+
+    if let Some(model_sig) = size_signature(&model_stem) {
+        // Require the projector to share the model's size signature.
+        return candidates.into_iter().find(|p| {
+            p.file_stem()
+                .and_then(|s| s.to_str())
+                .and_then(|s| size_signature(&s.to_ascii_lowercase()))
+                .as_deref()
+                == Some(model_sig.as_str())
+        });
+    }
+
+    // Model has no size signature: a single generic projector pairs cleanly;
+    // otherwise fall back to the best token overlap.
+    if candidates.len() == 1 {
+        return candidates.into_iter().next();
+    }
+    candidates.into_iter().max_by_key(|p| {
+        p.file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| token_overlap(&model_stem, &s.to_ascii_lowercase()))
+            .unwrap_or(0)
+    })
+}
+
+/// Discover every `(model, mmproj)` pair among the local GGUF models — i.e.
+/// every vision-capable model that has a matching projector beside it.
+///
+/// Ordering follows [`discover_local_models`] (directory priority, then
+/// filename), so it is stable across runs.
+pub fn discover_vision_models() -> Vec<(PathBuf, PathBuf)> {
+    discover_local_models()
+        .into_iter()
+        .filter_map(|model| resolve_mmproj_for(&model).map(|proj| (model, proj)))
+        .collect()
+}
+
+/// Resolve the vision model + projector to run for the unified local server.
+///
+/// Selection order:
+/// 1. A discovered vision model whose filename matches `preferred` (the
+///    `vision_model` setting), in either direction (substring).
+/// 2. A Gemma-4 **E4B** model — the unified default (small + fast).
+/// 3. The first vision-capable model discovered.
+///
+/// Returns `None` when no local model has a projector beside it.
+pub fn resolve_vision_model(preferred: &str) -> Option<(PathBuf, PathBuf)> {
+    let models = discover_vision_models();
+    if models.is_empty() {
+        return None;
+    }
+
+    let pref = preferred.trim().to_ascii_lowercase();
+    if !pref.is_empty() {
+        if let Some(found) = models.iter().find(|(m, _)| {
+            m.file_stem()
+                .and_then(|s| s.to_str())
+                .map(|s| {
+                    let s = s.to_ascii_lowercase();
+                    s.contains(&pref) || pref.contains(&s)
+                })
+                .unwrap_or(false)
+        }) {
+            return Some(found.clone());
+        }
+    }
+
+    if let Some(found) = models.iter().find(|(m, _)| {
+        m.file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_ascii_lowercase().contains("e4b"))
+            .unwrap_or(false)
+    }) {
+        return Some(found.clone());
+    }
+
+    models.into_iter().next()
+}
+
 /// Check if the model exists and is valid
 pub fn model_exists(models_dir: &Path) -> bool {
     let model_path = get_model_path(models_dir);
@@ -788,6 +950,57 @@ mod tests {
         let dot = dirs.iter().position(|p| p == &PathBuf::from(".models"));
         let plain = dirs.iter().position(|p| p == &PathBuf::from("models"));
         assert!(dot < plain);
+    }
+
+    #[test]
+    fn test_is_size_token() {
+        assert!(is_size_token("4b"));
+        assert!(is_size_token("12b"));
+        assert!(is_size_token("e4b"));
+        assert!(is_size_token("27b"));
+        assert!(!is_size_token("q4"));
+        assert!(!is_size_token("b"));
+        assert!(!is_size_token("mmproj"));
+        assert!(!is_size_token("gemma"));
+    }
+
+    #[test]
+    fn test_size_signature() {
+        assert_eq!(
+            size_signature("gemma-4-e4b_q4_0-it"),
+            Some("e4b".to_string())
+        );
+        assert_eq!(
+            size_signature("gemma-4-12b-it-qat-q4_0"),
+            Some("12b".to_string())
+        );
+        assert_eq!(size_signature("qwen3.5-4b-q4_k_s"), Some("4b".to_string()));
+        assert_eq!(size_signature("some-model-no-size"), None);
+    }
+
+    #[test]
+    fn test_resolve_mmproj_for_pairs_by_size() {
+        let dir = std::env::temp_dir().join("ss_mmproj_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let e4b = dir.join("gemma-4-E4B_q4_0-it.gguf");
+        let twelveb = dir.join("gemma-4-12b-it-qat-q4_0.gguf");
+        let qwen = dir.join("Qwen3.5-4B-Q4_K_S.gguf");
+        let proj_e4b = dir.join("gemma-4-E4B-it-mmproj.gguf");
+        let proj_12b = dir.join("mmproj-gemma-4-12b-it-qat-q4_0.gguf");
+        for f in [&e4b, &twelveb, &qwen, &proj_e4b, &proj_12b] {
+            std::fs::write(f, b"x").unwrap();
+        }
+
+        assert_eq!(resolve_mmproj_for(&e4b), Some(proj_e4b.clone()));
+        assert_eq!(resolve_mmproj_for(&twelveb), Some(proj_12b.clone()));
+        // Qwen has size sig 4b but no 4b projector → must not be paired.
+        assert_eq!(resolve_mmproj_for(&qwen), None);
+        // A projector is never its own projector.
+        assert_eq!(resolve_mmproj_for(&proj_e4b), None);
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]

--- a/screensearch-llm/src/lib.rs
+++ b/screensearch-llm/src/lib.rs
@@ -41,6 +41,8 @@ pub use config::{
 pub use download::{
     // Model discovery + download
     discover_local_models,
+    // Vision (multimodal projector) discovery
+    discover_vision_models,
     // llama-server download
     download_llama_server,
     download_llama_server_with_progress,
@@ -57,7 +59,9 @@ pub use download::{
     model_search_dirs,
     needs_download,
     needs_llama_server_download,
+    resolve_mmproj_for,
     resolve_model_path,
+    resolve_vision_model,
     DownloadProgress,
     LLAMA_SERVER_FILENAME,
     LLAMA_SERVER_SIZE_BYTES,

--- a/screensearch-llm/src/server.rs
+++ b/screensearch-llm/src/server.rs
@@ -68,6 +68,10 @@ impl ServerStatus {
 pub struct LlamaServerConfig {
     /// Path to the GGUF model file
     pub model_path: PathBuf,
+    /// Optional multimodal projector (mmproj) GGUF. When set, the server is
+    /// started with `--mmproj`, enabling vision input (image_url) for models
+    /// like Gemma 4. `None` = text-only server.
+    pub mmproj_path: Option<PathBuf>,
     /// Port to listen on
     pub port: u16,
     /// Host to bind to (always 127.0.0.1 for security)
@@ -89,6 +93,7 @@ impl Default for LlamaServerConfig {
     fn default() -> Self {
         Self {
             model_path: PathBuf::new(),
+            mmproj_path: None,
             port: DEFAULT_LLAMA_PORT,
             host: "127.0.0.1".to_string(),
             idle_ttl: Duration::from_secs(DEFAULT_IDLE_TTL_SECS),
@@ -171,6 +176,14 @@ impl LlamaServer {
     /// Update the configuration (requires restart to take effect)
     pub async fn update_config(&self, config: LlamaServerConfig) {
         *self.config.write().await = config;
+    }
+
+    /// The model + optional projector this server is configured to run. Used to
+    /// decide whether a cached server can be reused or must be rebuilt (e.g.
+    /// when vision is toggled and the unified model/projector changes).
+    pub async fn current_models(&self) -> (PathBuf, Option<PathBuf>) {
+        let config = self.config.read().await;
+        (config.model_path.clone(), config.mmproj_path.clone())
     }
 
     /// Update idle TTL
@@ -307,6 +320,14 @@ impl LlamaServer {
             // correct formatting of modern instruct models and to surface
             // reasoning/"thinking" output from models like Qwen3.5 / Gemma 4.
             .arg("--jinja");
+
+        // Load a multimodal projector when configured so the same server can
+        // also answer vision (image_url) requests (Option B: one unified
+        // gemma-4 server serves both text and vision).
+        if let Some(mmproj) = &config.mmproj_path {
+            info!("Enabling vision: loading mmproj projector {:?}", mmproj);
+            cmd.arg("--mmproj").arg(mmproj);
+        }
 
         // Add GPU flag if enabled (use configured number of layers)
         if use_gpu {

--- a/screensearch-ui/src/components/SettingsPanel.tsx
+++ b/screensearch-ui/src/components/SettingsPanel.tsx
@@ -684,7 +684,7 @@ export function SettingsPanel() {
                             onChange={(e) => setVisionProvider(e.target.value)}
                             className="w-full bg-background border border-input rounded-lg px-3 py-2 font-mono text-sm"
                           >
-                            <option value="local">Bundled local Ministral-3-3B</option>
+                            <option value="local">Bundled local model (auto-detected GGUF)</option>
                             <option value="ollama">Ollama-compatible local server</option>
                             <option value="openai">OpenAI-compatible endpoint</option>
                           </select>
@@ -697,7 +697,7 @@ export function SettingsPanel() {
                             <div className="space-y-3">
                               <div className="flex items-center gap-2">
                                 <Cpu className="h-4 w-4 text-primary" />
-                                <span className="font-medium">Ministral-3-3B Generation Model</span>
+                                <span className="font-medium">Local Generation Model</span>
                               </div>
 
                               {modelStatus?.downloaded ? (
@@ -839,6 +839,13 @@ export function SettingsPanel() {
 
                             <p className="text-xs text-muted-foreground pt-1">
                               Runs entirely on your device. Server starts automatically on first AI request.
+                            </p>
+                            <p className="text-xs text-muted-foreground">
+                              Vision uses a single unified server: it loads a Gemma&nbsp;4 model plus its
+                              <code className="mx-1 px-1 rounded bg-secondary/60">*mmproj*.gguf</code>
+                              projector (drop both into <code className="px-1 rounded bg-secondary/60">.models/</code>)
+                              so the same model answers both text and image questions. Screenshots are
+                              analyzed on demand and as a throttled background trickle.
                             </p>
                           </div>
                         )}

--- a/src/main.rs
+++ b/src/main.rs
@@ -533,8 +533,9 @@ impl App {
             warn!("Embedding worker did not start yet: {}", e);
         }
 
-        // Start vision analysis worker
-        screensearch_api::workers::vision_worker::spawn_vision_worker(Arc::clone(&db));
+        // Start vision analysis worker (shares AppState to drive the unified
+        // local llama-server with --mmproj for on-device vision).
+        api_server.start_vision_worker();
 
         let (frame_tx, frame_rx) = tokio::sync::mpsc::channel(100);
         let (processed_tx, mut processed_rx) = tokio::sync::mpsc::channel(100);


### PR DESCRIPTION
## Summary

Wires up **on-device vision (screen understanding)** on top of the existing auto-managed `llama.cpp` server. When vision is enabled with the `local` provider, the same server that answers AI reports is launched with `--mmproj` so a **single Gemma 4 model serves both text generation and image analysis** (Option B — unify on gemma-4). Vision is **off by default**.

Builds on merged #69 (llama.cpp b9728 + reasoning) — that already added `--jinja`, the version marker, and the 16384 context.

## What it does

- Analyzes the *pixels* of each screenshot (not just OCR text) and writes `description`, `visible_text`, `activity_type`, `app_hint`, `confidence` onto frames.
- Local provider runs entirely on-device; external providers (`ollama`/`openai`) are also supported.
- Enqueue is **on-demand** (`POST /api/vision/analyze/:frame_id`, high priority) plus a **throttled** background trickle of recent un-analyzed frames (batch 4) — bounds GPU rate, not total.

## Changes

**`screensearch-llm`**
- `mmproj_path` on `LlamaServerConfig` + `--mmproj` emission; `current_models()` accessor.
- `resolve_mmproj_for()` pairs a model with its projector by **size signature** (E4B↔E4B, 12B↔12B) so a text-only model like Qwen3.5 is never mis-paired; `discover_vision_models()`, `resolve_vision_model()` (prefers Gemma 4 E4B). Unit-tested.

**`screensearch-api`**
- `get_llama_server()` is vision-aware and rebuilds the unified server when vision toggles.
- Vision worker takes `Arc<AppState>` (via `ApiServer::start_vision_worker`), drives the local server over the OpenAI-compatible vision endpoint, on-demand + throttled enqueue.
- `handlers/vision.rs`: `POST /api/vision/analyze/:frame_id`, `GET /api/vision/status`. AI report now names the actually-loaded model.

**`screensearch-db`**
- `get_unanalyzed_frame_ids()` (throttle source) and `get_vision_status()` + `VisionStatus`.

**UI / docs**
- Settings copy updated for the unified local model + a vision/mmproj note.
- New `docs/vision.md`; vision threaded through README, PROJECT_INDEX, CODE_NAVIGATION, quick-reference, user-guide, developer-guide, security, index, embedded-llm; CHANGELOG.

## Validation (real Windows)

- `cargo check --workspace`, `cargo build --release`, clippy (llm/db/api), fmt — all clean. New mmproj unit test passes.
- Server launched with `--mmproj` (process cmdline): `-m ...gemma-4-E4B-it-qat-UD-Q2_K_XL.gguf ... --jinja --mmproj ...gemma-4-E4B-it-mmproj.gguf -ngl 99`.
- **On-demand**: frame 647 → `activity_type=entertainment`, `confidence=0.95`, `visible_text=["PLAY","IRON NEST","MENU","EXIT","SETTINGS"]` (read from the image — OCR text was only `"stem System ,Pressure menu"`).
- **Throttled trickle**: auto-completed frame 726 unaided (`activity=coding`, 21 s).
- **Text still works** on the same server: `/api/ai/generate` → `model_used=gemma-4-E4B-it-qat-UD-Q2_K_XL`, grounded report.

## Notes

- Default local vision model is the first Gemma 4 **E4B** by filename order (may be a low quant like Q2); set `vision_model` to pin a higher-quality quant. While vision is on, that model is also used for AI reports.
- `LocalClient::analyze` in `screensearch-vision` remains an unused TODO stub (the worker routes through `OllamaClient` against the local server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
