### PR TITLE
fix(vision): default to Gemma 4 E4B, surface GPU, add startup readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Settings AI card no longer hangs on its loading skeleton.** `GET
+  /embeddings/status`'s cheap `engine_ready` probe used a blocking read lock that
+  stalled for the entire first-run embedding-model download (~450 MB) because
+  `get_embedding_engine` holds the write lock across init. It now uses `try_read`
+  and reports "not ready" while initializing instead of blocking. A defensive 8s
+  fetch timeout in the UI also prevents the card from getting stuck. Files:
+  `screensearch-api/src/state.rs`, `screensearch-ui/src/components/EmbeddingsStatus.tsx`.
+- **`database is locked` errors under concurrent writes.** Added a SQLite
+  `busy_timeout` (10s) so a writer (e.g. the vision worker storing an analysis)
+  waits for the lock instead of erroring when the capture/OCR pipeline is also
+  writing. File: `screensearch-db/src/db.rs`.
+- **Answer Generation no longer spams `image input is not supported`.** The local
+  provider previously defaulted to the **text-only** Ministral-3B (`vision_model =
+  'ministral-3:3b'`), so enabling vision sent images to a server with no
+  multimodal projector and every frame failed. The default is now **Gemma 4 E4B**
+  (multimodal): a new DB migration (`011_gemma4_vision_default`) migrates existing
+  `ministral-3:3b` rows, and the Settings/AI UI defaults and labels were updated
+  off Ministral. Drop your Gemma 4 GGUF(s) + `*mmproj*.gguf` into `.models/` and
+  pick one in Settings → AI.
+
+### Added
+- **Startup readiness banner.** A new non-blocking banner explains, in plain
+  language, what the backend is doing while it warms up and roughly how long is
+  left — core services (DB/capture/OCR/search), the semantic-search model, and
+  local AI answer generation (server/model download + load, with GPU/CPU shown).
+  It only appears when there is actual warm-up to report (a fully-cached launch
+  shows nothing) and auto-dismisses once everything is ready. Backed by a new
+  `GET /api/system/readiness` aggregator. Files:
+  `screensearch-api/src/handlers/system.rs`, `routes.rs`,
+  `screensearch-ui/src/components/StartupStatus.tsx`, `App.tsx`.
+- **Vision model picker** — `GET /api/vision/models` lists the locally discovered
+  `(model, mmproj)` pairs, and Settings → AI shows a dropdown to choose which one
+  the unified local server loads (writes the `vision_model` setting; the server
+  rebuilds on the next request). Files: `screensearch-api/src/handlers/vision.rs`,
+  `routes.rs`, `screensearch-ui/src/components/SettingsPanel.tsx`.
+- **GPU acceleration is now visible.** `GET /api/ai/server/status` returns an
+  `acceleration` field (`gpu` / `cpu` / `unknown`) and Settings → AI shows whether
+  the local server is running on GPU (Vulkan) or fell back to CPU. llama-server's
+  stdout/stderr are captured to `bin/llama-server.log` (previously discarded), so
+  a Vulkan init failure is diagnosable. File: `screensearch-llm/src/server.rs`,
+  `screensearch-api/src/handlers/ai.rs`.
+
+### Changed
+- **Better local model selection.** `resolve_vision_model()` now prefers a
+  higher-quality quantization within a size tier (e.g. Q4 over Q2), and model
+  discovery skips non-loadable GGUFs (multimodal projectors, `mtp-*` helper heads,
+  and files below a size floor) so they're never loaded as the generation/vision
+  model. File: `screensearch-llm/src/download.rs`.
+- **GPU health-check timeout scales with model size** (base + per-GB, capped)
+  instead of a fixed 45 s, so a multi-GB model loading into VRAM is no longer
+  mistaken for a GPU failure and silently bounced to CPU. File:
+  `screensearch-llm/src/server.rs`.
+- **"Process frames" (embeddings indexing) no longer blocks.** `POST
+  /api/embeddings/generate` starts the CPU-bound work on a background task and
+  returns immediately; the UI polls `GET /api/embeddings/status` so the coverage
+  bar climbs live. Chunks are batched across frames (bounded per call) and the
+  fastembed batch size was raised 16 → 32 for better throughput. Files:
+  `screensearch-api/src/handlers/embeddings.rs`,
+  `screensearch-embeddings/src/lib.rs`,
+  `screensearch-ui/src/components/EmbeddingsStatus.tsx`.
+  (Note: embeddings still run on ONNX Runtime CPU; GPU execution providers are
+  future work.)
+- **UI rename:** the "ScreenSearch Intel" / "Intelligence" surfaces are now
+  branded **"Insights"** (dashboard title, reports page/header, search footer,
+  answer card, settings section; report files are saved as `insights-report-*`).
+
 ### Added
 - **On-device vision (screen understanding) via the unified local llama-server.**
   When vision is enabled with the `local` provider, the same auto-managed

--- a/docs/CODE_NAVIGATION.md
+++ b/docs/CODE_NAVIGATION.md
@@ -57,19 +57,30 @@
 
 | Concern | File |
 |---|---|
-| `--mmproj` flag and server config | `screensearch-llm/src/server.rs` |
-| Model/projector discovery | `screensearch-llm/src/download.rs` (`resolve_mmproj_for`, `resolve_vision_model`) |
+| `--mmproj` flag, GPU mode + log capture | `screensearch-llm/src/server.rs` (`gpu_active`, `gpu_health_timeout_secs`) |
+| Model/projector discovery + quant pick | `screensearch-llm/src/download.rs` (`resolve_mmproj_for`, `resolve_vision_model`, `quant_desirability`, `is_loadable_model_gguf`) |
 | Vision worker (queue consumer) | `screensearch-api/src/workers/vision_worker.rs` |
-| Vision endpoints (analyze, status) | `screensearch-api/src/handlers/vision.rs` |
+| Vision endpoints (analyze, status, models) | `screensearch-api/src/handlers/vision.rs` (`list_vision_models`) |
+| Server status incl. `acceleration` | `screensearch-api/src/handlers/ai.rs` (`get_server_status`) |
 | Queue and status queries | `screensearch-db/src/queries.rs` (`enqueue_frame_for_analysis`, `get_unanalyzed_frame_ids`, `get_vision_status`) |
-| `vision_*` settings columns | `screensearch-db/src/migrations.rs` |
+| `vision_*` settings columns + Gemma 4 default | `screensearch-db/src/migrations.rs` (`011_gemma4_vision_default`) |
+
+## Startup & Readiness
+
+| Concern | File |
+|---|---|
+| Readiness aggregator endpoint | `screensearch-api/src/handlers/system.rs` (`get_readiness`) |
+| Startup banner | `screensearch-ui/src/components/StartupStatus.tsx` |
+| Non-blocking engine-ready probe | `screensearch-api/src/state.rs` (`embedding_engine_initialized`) |
+| SQLite `busy_timeout` | `screensearch-db/src/db.rs` |
 
 ## Frontend
 
 | Concern | File |
 |---|---|
-| Settings panel | `screensearch-ui/src/components/SettingsPanel.tsx` |
-| Quality-stack status | `screensearch-ui/src/components/EmbeddingsStatus.tsx` |
+| Settings panel + vision model picker + GPU badge | `screensearch-ui/src/components/SettingsPanel.tsx` |
+| Quality-stack status / "Process frames" | `screensearch-ui/src/components/EmbeddingsStatus.tsx` |
+| Startup readiness banner | `screensearch-ui/src/components/StartupStatus.tsx` |
 | Search mode selection | `screensearch-ui/src/components/SearchBar.tsx` |
 | Search invitation | `screensearch-ui/src/components/search/SearchInvite.tsx` |
 | Generation provider page | `screensearch-ui/src/components/AiSettings.tsx` |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,6 +14,28 @@
 Returns application health, version, uptime, frame count, and recent capture
 information.
 
+### `GET /system/readiness`
+
+Aggregated startup readiness across subsystems, in plain language for the UI's
+startup banner. Cheap and non-blocking, designed to be polled ~once a second
+while the backend warms up.
+
+```bash
+curl "http://127.0.0.1:3131/api/system/readiness"
+# -> {"core_ready":true,"all_ready":false,"stages":[
+#      {"id":"core","label":"Core services","state":"ready",
+#       "detail":"Capture, OCR, and keyword search are running.","progress":null,"eta_seconds":null},
+#      {"id":"search_index","label":"Semantic search","state":"loading",
+#       "detail":"Loading the search model — the first run downloads ~450 MB.",...},
+#      {"id":"answer_generation","label":"AI answer generation","state":"downloading",
+#       "detail":"Downloading the local AI server…","progress":42.5,"eta_seconds":37}]}
+```
+
+`state` is one of `ready`, `initializing`, `loading`, `downloading`,
+`needs_setup`, or `disabled`. `initializing`/`loading`/`downloading` are
+*transitional* (timed warm-up); `all_ready` is `true` when none remain. `progress`
+(0–100) and `eta_seconds` are present only for `downloading`.
+
 ## Search
 
 ### `GET /search/`
@@ -195,7 +217,7 @@ Example:
   "retention_days": 30,
   "vision_enabled": 1,
   "vision_provider": "local",
-  "vision_model": "ministral-3:3b",
+  "vision_model": "gemma-4-E4B",
   "vision_endpoint": "http://127.0.0.1:31130",
   "vision_api_key": null
 }
@@ -247,7 +269,7 @@ Generates a report over a time range:
 |---|---|---|
 | `GET` | `/ai/model/status` | Local model status, including an `available_models` list |
 | `POST` | `/ai/model/download` | Start local model download |
-| `GET` | `/ai/server/status` | llama-server state |
+| `GET` | `/ai/server/status` | llama-server state, incl. `acceleration` (`gpu`/`cpu`/`unknown`) |
 | `POST` | `/ai/server/start` | Start llama-server |
 | `POST` | `/ai/server/stop` | Stop llama-server |
 | `POST` | `/ai/server/ttl` | Set idle shutdown timeout |
@@ -292,6 +314,25 @@ curl "http://127.0.0.1:3131/api/vision/status"
 #     "total_frames":1024,"completed":300,"pending":4,"processing":1,
 #     "failed":0,"queue_depth":5}
 ```
+
+### `GET /vision/models`
+
+List the locally discovered vision-capable models — each a GGUF in `.models/`
+paired with a matching `*mmproj*.gguf` projector — so the UI can offer a picker
+for the local provider. The entry the server currently resolves to (from the
+`vision_model` setting) is flagged `selected`.
+
+```bash
+curl "http://127.0.0.1:3131/api/vision/models"
+# -> {"models":[
+#       {"id":"gemma-4-E4B-it-qat-UD-Q4_K_XL","model_file":"gemma-4-E4B-it-qat-UD-Q4_K_XL.gguf",
+#        "mmproj_file":"gemma-4-E4B-it-mmproj.gguf","selected":true}],
+#     "selected":"gemma-4-E4B-it-qat-UD-Q4_K_XL"}
+```
+
+Set the `vision_model` setting to a model's `id` (or any substring of it) to
+select it; the unified local server rebuilds with that model + projector on the
+next request.
 
 ## Download Progress
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,6 +199,19 @@ bounding GPU load. Results are written back to each frame (`description`,
 providers (Ollama / OpenAI-compatible), the worker targets the configured
 endpoint instead and no local server is started.
 
+Selection prefers the **best quantization** within a tier (Q4 over Q2/Q3), and
+discovery ignores non-loadable GGUFs (projectors, `mtp-*` heads, undersized
+files). The default `vision_model` is **Gemma 4 E4B**; `GET /api/vision/models`
+lists discovered `(model, mmproj)` pairs for the Settings picker. The default was
+previously the text-only Ministral-3B, which could not answer image requests —
+see `docs/vision.md`.
+
+**GPU visibility.** The server is launched with `-ngl 99` (Vulkan) and falls back
+to CPU only if initialization fails. llama-server's stdout/stderr are captured to
+`bin/llama-server.log`, the GPU-mode health-check timeout scales with model size
+(so large models aren't bounced to CPU prematurely), and `GET /api/ai/server/status`
+exposes `acceleration` (`gpu`/`cpu`/`unknown`) which the UI surfaces as a badge.
+
 ## Runtime Status
 
 `GET /api/embeddings/status` exposes:
@@ -217,6 +230,32 @@ until the engine is ready or an error is reported.
 The dashboard uses this response to distinguish ready, indexing, degraded, and
 error states. Grounded generation is disabled when required inference is
 unavailable.
+
+The `engine_ready` probe (`AppState::embedding_engine_initialized`) uses a
+non-blocking `try_read`, so it returns immediately even while the engine is being
+loaded under the write lock during the first-run model download — it never stalls
+`GET /embeddings/status`.
+
+### On-demand indexing
+
+`POST /api/embeddings/generate` ("Process frames" in the UI) starts the
+CPU-bound work on a **background task** and returns immediately; the UI polls
+`GET /embeddings/status` so coverage climbs live without blocking the request. A
+process-wide guard prevents overlapping jobs, and chunks are embedded in
+size-bounded cross-frame batches (one model-lock hop per batch instead of per
+frame) so large backlogs don't starve search-time query embedding.
+
+### Startup readiness
+
+`GET /api/system/readiness` aggregates a single, cheap, non-blocking view of
+warm-up across three subsystems — **core** (DB + capture/OCR/search), **semantic
+search** (embedding model load), and **AI answer generation** (server/model
+download + load, with GPU/CPU) — each as a stage with a `state`
+(`ready`/`initializing`/`loading`/`downloading`/`needs_setup`/`disabled`),
+plain-language `detail`, and `progress`/`eta_seconds` for tracked downloads. The
+frontend's `StartupStatus` banner polls it during warm-up to explain what's
+happening and roughly how long remains, auto-hiding once `all_ready`. A
+fully-cached launch reports `all_ready` immediately and shows no banner.
 
 ## Packaging
 

--- a/docs/embedded-llm.md
+++ b/docs/embedded-llm.md
@@ -595,7 +595,7 @@ interface AppStore {
   aiConfig: {
     providerUrl: string;      // Default: 'local'
     apiKey: string;           // Default: ''
-    model: string;            // Default: 'ministral-3b'
+    model: string;            // Default: 'gemma-4-E4B' (vision-capable)
   };
   setAiConfig: (config: Partial<AiConfig>) => void;
 }
@@ -605,7 +605,7 @@ interface AppStore {
 
 ```typescript
 const PROVIDER_OPTIONS = [
-  { value: 'local', label: 'Bundled Ministral-3-3B', description: 'Optional local answer-generation model' },
+  { value: 'local', label: 'Bundled Gemma 4 E4B (vision)', description: 'Optional on-device model for answers, reports, and screenshot understanding' },
   { value: 'http://localhost:11434/v1', label: 'Ollama-compatible', description: 'Local generation server' },
   { value: 'custom', label: 'OpenAI-compatible', description: 'Remote or local generation endpoint' },
 ];
@@ -662,7 +662,8 @@ if config.use_gpu {
 
 ### 9.3 Expected GPU Output
 
-When llama-server starts with GPU acceleration:
+llama-server's stdout/stderr are captured to **`bin/llama-server.log`** (next to
+the binary), so the Vulkan device and offloaded-layer summary are visible:
 ```
 ggml_vulkan: Using AMD Radeon RX 7900 XTX (RADV)
 ggml_vulkan: Device memory: 24576 MB
@@ -674,9 +675,20 @@ ggml_vulkan: Using NVIDIA GeForce RTX 4090
 ggml_vulkan: Device memory: 24564 MB
 ```
 
-### 9.4 CPU Fallback
+### 9.4 CPU Fallback and acceleration status
 
-If no Vulkan-compatible GPU is found, llama-server automatically falls back to CPU inference. Performance will be slower but functional.
+If no Vulkan-compatible GPU is found (or initialization fails), llama-server
+automatically falls back to CPU inference — slower but functional. Two signals
+make the active mode observable rather than silent:
+
+- **`GET /api/ai/server/status`** returns an `acceleration` field
+  (`"gpu"` / `"cpu"` / `"unknown"`), surfaced in Settings → Data & AI as a
+  **"Running on GPU (Vulkan)"** / **"Running on CPU"** badge.
+- The **GPU-mode health-check timeout scales with model size** (base + per-GB,
+  capped) instead of a fixed short value, so a multi-GB model loading into VRAM
+  on first use is given enough time and is not mistaken for a GPU failure and
+  bounced to CPU. If the badge unexpectedly says CPU, `bin/llama-server.log`
+  shows the Vulkan reason.
 
 ---
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -42,12 +42,25 @@ back to the first discovered text GGUF.
 - `resolve_vision_model()` chooses the unified model. It first tries to match the
   `vision_model` setting against a discovered model filename; otherwise it
   prefers a **Gemma 4 E4B** model; otherwise it uses the first vision-capable
-  model found.
+  model found. **Within each of those tiers it picks the best quantization** —
+  Q4 is favoured over a lower Q2/Q3 and over heavier Q6/Q8 quants — so dropping
+  several quants of the same model into `.models/` selects a sensible default
+  automatically (see `quant_desirability`).
+- Model discovery (`discover_local_models`) skips files that are **not loadable
+  primary models**: multimodal projectors (`*mmproj*.gguf`), non-standalone
+  helper heads (`mtp-*.gguf`), and any GGUF below a size floor (so a truncated
+  download is ignored).
 - `resolve_mmproj_for()` pairs that model with the correct `*mmproj*.gguf`
   projector sitting beside it, matched by **size signature** (e.g. an `E4B` model
   gets the `E4B` projector, a `12B` model the `12B` projector). A text-only model
   such as Qwen3.5 has no matching projector and is never mis-paired.
 - A model is "vision-capable" only if a matching projector is found next to it.
+
+The default `vision_model` setting is **`gemma-4-E4B`** (migration
+`011_gemma4_vision_default`), which the substring match resolves to whichever
+E4B quant you provide. To pin an exact file, choose it in **Settings → Data & AI
+→ Vision model** (a dropdown populated from `GET /api/vision/models`), or set
+`vision_model` to a substring of the filename (e.g. `Q4_K_XL`).
 
 ## Setup (local, on-device)
 
@@ -74,11 +87,30 @@ back to the first discovered text GGUF.
 4. The worker starts the unified server (first request loads the model; this can
    take 20–60 s) and begins analyzing frames.
 
-> **Tip — model quality.** If `vision_model` does not match a specific file, the
-> first Gemma 4 **E4B** by filename order is used, which may be a low-quality
-> quant (e.g. `Q2_K_XL`). Set `vision_model` to a substring of the exact file you
-> want (e.g. `Q4_K_XL`) to pin a higher-quality quant. The same model is then
-> also used for AI reports while vision is enabled.
+> **Tip — pick the model.** When several Gemma 4 quants sit in `.models/`,
+> selection prefers a **Q4** automatically. To force a specific file, use the
+> **Vision model** dropdown in Settings → Data & AI (or set `vision_model` to a
+> substring such as `Q4_K_XL`). The chosen model also serves AI reports while
+> vision is enabled.
+
+### GPU acceleration (Vulkan) and visibility
+
+The unified server is launched with `-ngl 99` to offload all layers to the GPU
+via the Vulkan llama.cpp build, falling back to CPU if Vulkan initialization
+fails. Two things make the GPU path observable:
+
+- **llama-server logs are captured to `bin/llama-server.log`** (previously
+  discarded). Vulkan device selection, the offloaded-layer summary, and any
+  fallback reason are visible there.
+- **`GET /api/ai/server/status` reports `acceleration`** (`"gpu"`, `"cpu"`, or
+  `"unknown"`), and Settings → Data & AI shows a **"Running on GPU (Vulkan)"** /
+  **"Running on CPU"** badge while the server is up.
+
+The GPU-mode health-check timeout **scales with model size** (base + per-GB,
+capped), so a multi-GB model loading into VRAM on first use is not mistaken for a
+GPU failure and bounced to CPU. If the badge says CPU unexpectedly, check
+`bin/llama-server.log` for the Vulkan reason (e.g. missing runtime, no compatible
+device).
 
 ## Setup (external provider)
 
@@ -109,6 +141,8 @@ already queued.
 |---|---|---|
 | `POST` | `/api/vision/analyze/:frame_id` | Enqueue one frame (on demand) |
 | `GET`  | `/api/vision/status` | Provider/model, per-status counts, queue depth |
+| `GET`  | `/api/vision/models` | Discovered `(model, mmproj)` pairs for the picker; flags the selected one |
+| `GET`  | `/api/ai/server/status` | Server state incl. `acceleration` (`gpu`/`cpu`) |
 | `POST` | `/api/test-vision` | Test the configured vision/generation provider |
 
 See `docs/api-reference.md` for request/response details.
@@ -135,6 +169,11 @@ window title for each analyzed frame are sent to the configured endpoint. See
 
 ## Troubleshooting
 
+- **`image input is not supported … you may need to provide the mmproj`**: the
+  loaded model is **text-only** (no projector). This happened when the default
+  `vision_model` was Ministral-3B; the default is now **Gemma 4 E4B**. Ensure a
+  Gemma 4 model **and** its `*mmproj*.gguf` are in `.models/`, then pick it in
+  Settings → Data & AI → Vision model.
 - **Nothing gets analyzed / `queue_depth` stays 0**: confirm `vision_enabled=1`
   and (local) that llama-server is downloaded and current. The worker logs
   `Vision enabled (local) but llama-server is not downloaded/current` when the
@@ -144,5 +183,12 @@ window title for each analyzed frame are sent to the configured endpoint. See
   Add the projector for your Gemma 4 model.
 - **First analysis is slow**: the unified server loads the model on the first
   request (20–60 s). Subsequent frames are much faster.
-- **Results are low quality**: pin a higher-quality quant via `vision_model`
-  (see the tip above).
+- **Server runs on CPU instead of GPU**: check the `acceleration` badge in
+  Settings → Data & AI and `bin/llama-server.log` for the Vulkan reason. The
+  GPU health-check timeout scales with model size, so large models are given
+  enough time to load into VRAM before any CPU fallback.
+- **Results are low quality**: pick a higher-quality quant in the Vision model
+  dropdown (or pin one via `vision_model`).
+- **`database is locked` in the vision worker**: addressed by a SQLite
+  `busy_timeout`; the writer now waits for the lock under concurrent capture/OCR
+  writes instead of erroring.

--- a/screensearch-api/src/handlers/ai.rs
+++ b/screensearch-api/src/handlers/ai.rs
@@ -698,6 +698,10 @@ pub struct ServerStatusResponse {
     pub idle_seconds: u64,
     pub model_loaded: bool,
     pub server_binary_available: bool,
+    /// Which acceleration the running server actually started in:
+    /// `"gpu"` (Vulkan), `"cpu"`, or `"unknown"` when not running. Lets the UI
+    /// surface a silent GPU→CPU fallback.
+    pub acceleration: String,
 }
 
 /// GET /ai/server/status
@@ -718,6 +722,11 @@ pub async fn get_server_status(
         let status = server.status().await;
         let port = server.active_port().await;
         let idle_duration = server.idle_duration().await;
+        let acceleration = match server.gpu_active().await {
+            Some(true) => "gpu",
+            Some(false) => "cpu",
+            None => "unknown",
+        };
 
         Ok(Json(ServerStatusResponse {
             status: status.as_str().to_string(),
@@ -725,6 +734,7 @@ pub async fn get_server_status(
             idle_seconds: idle_duration.as_secs(),
             model_loaded: status == ServerStatus::Running,
             server_binary_available,
+            acceleration: acceleration.to_string(),
         }))
     } else {
         Ok(Json(ServerStatusResponse {
@@ -733,6 +743,7 @@ pub async fn get_server_status(
             idle_seconds: 0,
             model_loaded: false,
             server_binary_available,
+            acceleration: "unknown".to_string(),
         }))
     }
 }

--- a/screensearch-api/src/handlers/embeddings.rs
+++ b/screensearch-api/src/handlers/embeddings.rs
@@ -138,12 +138,21 @@ pub async fn generate_embeddings(
 
     let job_state = Arc::clone(&state);
     tokio::spawn(async move {
+        // Reset the guard via Drop so the flag is cleared even if the job panics
+        // or the task is cancelled — otherwise it would block all future jobs.
+        struct JobGuard;
+        impl Drop for JobGuard {
+            fn drop(&mut self) {
+                EMBEDDING_JOB_RUNNING.store(false, Ordering::SeqCst);
+            }
+        }
+        let _guard = JobGuard;
+
         let processed = run_embedding_job(&job_state, batch_size).await;
         info!(
             "Background embedding job finished: {} frame(s) processed",
             processed
         );
-        EMBEDDING_JOB_RUNNING.store(false, Ordering::SeqCst);
     });
 
     Ok(Json(GenerateEmbeddingsResponse {

--- a/screensearch-api/src/handlers/embeddings.rs
+++ b/screensearch-api/src/handlers/embeddings.rs
@@ -7,8 +7,16 @@ use crate::error::Result;
 use crate::state::AppState;
 use axum::extract::{Json, State};
 use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-use tracing::{debug, warn};
+use tracing::{debug, info, warn};
+
+/// Guards against overlapping on-demand embedding jobs: clicking "Process
+/// frames" repeatedly should not spawn several concurrent passes over the same
+/// backlog. The background `embedding_worker` and this on-demand handler both
+/// insert idempotently (unique chunk constraint), so this is purely to avoid
+/// wasted, redundant work.
+static EMBEDDING_JOB_RUNNING: AtomicBool = AtomicBool::new(false);
 
 // ============================================================
 // Models
@@ -94,7 +102,11 @@ pub async fn prepare_quality_models(
 }
 
 /// POST /embeddings/generate
-/// Trigger background embedding generation for frames without embeddings
+/// Kick off embedding generation for frames without embeddings.
+///
+/// This returns immediately and runs the (CPU-bound, potentially multi-minute)
+/// work on a background task so the request — and the UI — never block. Progress
+/// is observed via `GET /embeddings/status` (coverage climbs as frames finish).
 pub async fn generate_embeddings(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<GenerateEmbeddingsRequest>,
@@ -102,12 +114,9 @@ pub async fn generate_embeddings(
     let batch_size = payload.batch_size.unwrap_or(50);
     debug!("Triggering embedding generation for {} frames", batch_size);
 
-    // Get frames without embeddings
-    let frames = state.db.get_frames_without_embeddings(batch_size).await?;
-
-    let frames_count = frames.len() as i64;
-
-    if frames_count == 0 {
+    // Cheap pre-check so the common "nothing to do" case answers instantly.
+    let pending = state.db.get_frames_without_embeddings(1).await?;
+    if pending.is_empty() {
         return Ok(Json(GenerateEmbeddingsResponse {
             success: true,
             message: "All frames already have embeddings".to_string(),
@@ -115,22 +124,63 @@ pub async fn generate_embeddings(
         }));
     }
 
-    // Get or initialize the embedding engine
+    // Refuse to stack overlapping jobs; one is already draining the backlog.
+    if EMBEDDING_JOB_RUNNING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Ok(Json(GenerateEmbeddingsResponse {
+            success: true,
+            message: "Embedding generation is already running in the background".to_string(),
+            frames_processed: 0,
+        }));
+    }
+
+    let job_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        let processed = run_embedding_job(&job_state, batch_size).await;
+        info!(
+            "Background embedding job finished: {} frame(s) processed",
+            processed
+        );
+        EMBEDDING_JOB_RUNNING.store(false, Ordering::SeqCst);
+    });
+
+    Ok(Json(GenerateEmbeddingsResponse {
+        success: true,
+        message: "Embedding generation started in the background".to_string(),
+        frames_processed: 0,
+    }))
+}
+
+/// Embed up to `batch_size` frames that lack embeddings. Chunks are batched
+/// across frames into a single `embed_batch` call (one model lock / blocking-pool
+/// hop instead of one per frame), then sliced back per frame for atomic storage.
+/// Returns the number of frames stored.
+async fn run_embedding_job(state: &Arc<AppState>, batch_size: i64) -> i64 {
+    let frames = match state.db.get_frames_without_embeddings(batch_size).await {
+        Ok(f) => f,
+        Err(error) => {
+            warn!("Failed to fetch frames for embedding: {}", error);
+            return 0;
+        }
+    };
+    if frames.is_empty() {
+        return 0;
+    }
+
     let engine = match state.get_embedding_engine().await {
         Ok(e) => e,
         Err(e) => {
-            return Ok(Json(GenerateEmbeddingsResponse {
-                success: false,
-                message: format!("Failed to initialize embedding engine: {}", e),
-                frames_processed: 0,
-            }));
+            warn!("Failed to initialize embedding engine: {}", e);
+            return 0;
         }
     };
 
-    let mut processed = 0;
-
-    for frame in frames {
-        // Get OCR text for the frame
+    // 1. Build per-frame chunk lists, dropping empty chunks so the flattened
+    //    order stays aligned with `embed_batch`'s output (which skips blanks).
+    let mut per_frame: Vec<(i64, Vec<String>)> = Vec::new();
+    for frame in &frames {
         let ocr_texts = match state.db.get_ocr_text_for_frame(frame.id).await {
             Ok(texts) => texts,
             Err(error) => {
@@ -138,12 +188,10 @@ pub async fn generate_embeddings(
                 continue;
             }
         };
-
         if ocr_texts.is_empty() {
             continue;
         }
 
-        // Combine OCR text and chunk it
         let ocr_text: String = ocr_texts
             .iter()
             .map(|o| o.text.as_str())
@@ -159,69 +207,123 @@ pub async fn generate_embeddings(
         let chunks = match engine.chunk_text(&combined_text, 512, 64).await {
             Ok(chunks) => chunks,
             Err(error) => {
-                tracing::warn!("Failed to chunk frame {}: {}", frame.id, error);
+                warn!("Failed to chunk frame {}: {}", frame.id, error);
                 continue;
             }
         };
-
-        let chunk_refs: Vec<&str> = chunks.iter().map(String::as_str).collect();
-        let embeddings = match engine.embed_batch(&chunk_refs).await {
-            Ok(embeddings) => embeddings,
-            Err(error) => {
-                tracing::warn!("Failed to embed frame {}: {}", frame.id, error);
-                continue;
-            }
-        };
-
-        let new_embeddings = chunks
-            .iter()
-            .zip(embeddings)
-            .enumerate()
-            .map(
-                |(chunk_index, (chunk_text, embedding))| screensearch_db::NewEmbedding {
-                    frame_id: frame.id,
-                    chunk_text: chunk_text.clone(),
-                    chunk_index: chunk_index as i32,
-                    embedding,
-                    provider: engine.provider().to_string(),
-                    model: engine.model().to_string(),
-                    model_version: engine.model_version().to_string(),
-                    content_hash: screensearch_embeddings::EmbeddingEngine::content_hash(
-                        chunk_text,
-                    ),
-                },
-            )
+        let chunks: Vec<String> = chunks
+            .into_iter()
+            .filter(|c| !c.trim().is_empty())
             .collect();
+        if !chunks.is_empty() {
+            per_frame.push((frame.id, chunks));
+        }
+    }
 
-        if let Err(error) = state.db.insert_embeddings(new_embeddings).await {
+    if per_frame.is_empty() {
+        return 0;
+    }
+
+    // 2. Embed in groups that bound each `embed_batch` to ~MAX_CHUNKS_PER_CALL
+    //    chunks. This batches several small frames per call (fewer model-lock /
+    //    blocking-pool hops than one-frame-at-a-time) without holding the shared
+    //    model lock for the whole backlog, which would starve search-time query
+    //    embedding.
+    const MAX_CHUNKS_PER_CALL: usize = 64;
+    let mut processed = 0;
+    let mut i = 0;
+    while i < per_frame.len() {
+        // Accumulate frames until the chunk budget would be exceeded (always
+        // take at least one frame, even if it alone exceeds the budget).
+        let mut group_end = i;
+        let mut chunk_count = 0;
+        while group_end < per_frame.len()
+            && (group_end == i || chunk_count + per_frame[group_end].1.len() <= MAX_CHUNKS_PER_CALL)
+        {
+            chunk_count += per_frame[group_end].1.len();
+            group_end += 1;
+        }
+        let group = &per_frame[i..group_end];
+        i = group_end;
+
+        let flat: Vec<&str> = group
+            .iter()
+            .flat_map(|(_, chunks)| chunks.iter().map(String::as_str))
+            .collect();
+        let embeddings = match engine.embed_batch(&flat).await {
+            Ok(e) => e,
+            Err(error) => {
+                warn!("Failed to embed batch of {} chunks: {}", flat.len(), error);
+                continue;
+            }
+        };
+        if embeddings.len() != flat.len() {
+            // Defensive: a length mismatch would corrupt the per-frame slicing.
             warn!(
-                "Failed to atomically store embeddings for frame {}: {}",
-                frame.id, error
+                "Embedding count {} != chunk count {}; skipping group",
+                embeddings.len(),
+                flat.len()
             );
             continue;
         }
 
-        processed += 1;
+        // Slice the flat embeddings back per frame and store atomically.
+        let mut cursor = 0usize;
+        for (frame_id, chunks) in group {
+            let slice = &embeddings[cursor..cursor + chunks.len()];
+            cursor += chunks.len();
 
-        // Update last processed frame ID
-        let _ = state
-            .db
-            .set_metadata("embeddings_last_processed_frame_id", &frame.id.to_string())
-            .await;
+            let new_embeddings = chunks
+                .iter()
+                .zip(slice.iter())
+                .enumerate()
+                .map(
+                    |(chunk_index, (chunk_text, embedding))| screensearch_db::NewEmbedding {
+                        frame_id: *frame_id,
+                        chunk_text: chunk_text.clone(),
+                        chunk_index: chunk_index as i32,
+                        embedding: embedding.clone(),
+                        provider: engine.provider().to_string(),
+                        model: engine.model().to_string(),
+                        model_version: engine.model_version().to_string(),
+                        content_hash: screensearch_embeddings::EmbeddingEngine::content_hash(
+                            chunk_text,
+                        ),
+                    },
+                )
+                .collect();
+
+            if let Err(error) = state.db.insert_embeddings(new_embeddings).await {
+                warn!(
+                    "Failed to atomically store embeddings for frame {}: {}",
+                    frame_id, error
+                );
+                continue;
+            }
+
+            processed += 1;
+            let _ = state
+                .db
+                .set_metadata("embeddings_last_processed_frame_id", &frame_id.to_string())
+                .await;
+        }
     }
 
-    if processed > 0 && state.db.get_frames_without_embeddings(1).await?.is_empty() {
+    if processed > 0
+        && state
+            .db
+            .get_frames_without_embeddings(1)
+            .await
+            .map(|f| f.is_empty())
+            .unwrap_or(false)
+    {
         let _ = state
             .db
             .set_metadata("embeddings_reindex_required", "false")
             .await;
     }
 
-    Ok(Json(GenerateEmbeddingsResponse {
-        success: true,
-        message: format!("Processed {} frames with embeddings", processed),
-        frames_processed: processed,
-    }))
+    processed
 }
 
 /// POST /embeddings/enable

--- a/screensearch-api/src/handlers/system.rs
+++ b/screensearch-api/src/handlers/system.rs
@@ -100,8 +100,6 @@ fn is_transitional(state: &str) -> bool {
 /// answer generation (server/model download + load). Designed to be cheap and
 /// non-blocking so it can be polled once a second during warm-up.
 pub async fn get_readiness(State(state): State<Arc<AppState>>) -> Result<Json<ReadinessResponse>> {
-    use screensearch_llm::{get_bin_dir, llama_server_up_to_date, resolve_vision_model};
-
     let mut stages: Vec<ReadinessStage> = Vec::new();
 
     // --- Core (database + API + capture/OCR pipeline) ---
@@ -174,6 +172,23 @@ pub async fn get_readiness(State(state): State<Arc<AppState>>) -> Result<Json<Re
             .map(|s| s.vision_model.clone())
             .unwrap_or_default();
 
+        // The local path needs filesystem checks (binary version marker, scan of
+        // .models/). Run them off the async executor so this frequently-polled
+        // handler never blocks the runtime on blocking syscalls.
+        let (server_ready, vision_present) = if vision_enabled && provider == "local" {
+            let vm = vision_model.clone();
+            tokio::task::spawn_blocking(move || {
+                (
+                    screensearch_llm::llama_server_up_to_date(&screensearch_llm::get_bin_dir()),
+                    screensearch_llm::resolve_vision_model(&vm).is_some(),
+                )
+            })
+            .await
+            .unwrap_or((false, false))
+        } else {
+            (false, false)
+        };
+
         let (st, detail, progress, eta): (String, String, Option<f64>, Option<u64>) =
             if !vision_enabled {
                 (
@@ -203,14 +218,14 @@ pub async fn get_readiness(State(state): State<Arc<AppState>>) -> Result<Json<Re
                     Some(p.percentage()),
                     Some(p.eta_seconds),
                 )
-            } else if !llama_server_up_to_date(&get_bin_dir()) {
+            } else if !server_ready {
                 (
                     "needs_setup".into(),
                     "Download the local AI server in Settings → Data & AI.".into(),
                     None,
                     None,
                 )
-            } else if resolve_vision_model(&vision_model).is_none() {
+            } else if !vision_present {
                 (
                     "needs_setup".into(),
                     "Add a Gemma 4 model and its *mmproj*.gguf to the .models/ folder.".into(),
@@ -219,42 +234,52 @@ pub async fn get_readiness(State(state): State<Arc<AppState>>) -> Result<Json<Re
                 )
             } else {
                 // Binary + model are present: reflect the server's runtime state.
-                let guard = state.llama_server.read().await;
-                match guard.as_ref() {
-                    Some(server) => {
-                        let status = server.status().await;
-                        match status.as_str() {
-                            "running" => {
-                                let accel = match server.gpu_active().await {
-                                    Some(true) => "GPU (Vulkan)",
-                                    Some(false) => "CPU",
-                                    None => "your device",
-                                };
-                                (
+                // `try_read` so a held write lock (server (re)building/shutting
+                // down) reports a transitional state instead of blocking this
+                // frequently-polled handler.
+                match state.llama_server.try_read() {
+                    Ok(guard) => match guard.as_ref() {
+                        Some(server) => {
+                            let status = server.status().await;
+                            match status.as_str() {
+                                "running" => {
+                                    let accel = match server.gpu_active().await {
+                                        Some(true) => "GPU (Vulkan)",
+                                        Some(false) => "CPU",
+                                        None => "your device",
+                                    };
+                                    (
+                                        "ready".into(),
+                                        format!("Local model loaded on {accel}."),
+                                        None,
+                                        None,
+                                    )
+                                }
+                                "starting" => (
+                                    "loading".into(),
+                                    "Loading the model into memory (first request can take a few seconds)…"
+                                        .into(),
+                                    None,
+                                    None,
+                                ),
+                                _ => (
                                     "ready".into(),
-                                    format!("Local model loaded on {accel}."),
+                                    "Ready — the model loads on the first request.".into(),
                                     None,
                                     None,
-                                )
+                                ),
                             }
-                            "starting" => (
-                                "loading".into(),
-                                "Loading the model into memory (first request can take a few seconds)…"
-                                    .into(),
-                                None,
-                                None,
-                            ),
-                            _ => (
-                                "ready".into(),
-                                "Ready — the model loads on the first request.".into(),
-                                None,
-                                None,
-                            ),
                         }
-                    }
-                    None => (
-                        "ready".into(),
-                        "Ready — the model loads on the first request.".into(),
+                        None => (
+                            "ready".into(),
+                            "Ready — the model loads on the first request.".into(),
+                            None,
+                            None,
+                        ),
+                    },
+                    Err(_) => (
+                        "loading".into(),
+                        "Initializing the local AI server…".into(),
                         None,
                         None,
                     ),
@@ -803,6 +828,7 @@ pub async fn list_monitors() -> Result<Json<Vec<MonitorInfoDto>>> {
 
 /// POST /api/test-vision - Test vision configuration
 pub async fn test_vision_config(
+    State(state): State<Arc<AppState>>,
     Json(req): Json<TestVisionRequest>,
 ) -> Result<Json<serde_json::Value>> {
     debug!(
@@ -821,17 +847,30 @@ pub async fn test_vision_config(
             })));
         }
 
-        // Check if llama-server is running by hitting health endpoint
+        // Check if llama-server is running by hitting its health endpoint on the
+        // port it actually bound (it falls back to 31131/31132 if 31130 is busy).
+        let port = match state.llama_server.try_read() {
+            Ok(guard) => match guard.as_ref() {
+                Some(server) => server.active_port().await,
+                None => screensearch_llm::DEFAULT_LLAMA_PORT,
+            },
+            Err(_) => screensearch_llm::DEFAULT_LLAMA_PORT,
+        };
+
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(5))
             .build()
             .unwrap_or_default();
 
-        match client.get("http://127.0.0.1:31130/health").send().await {
+        match client
+            .get(format!("http://127.0.0.1:{port}/health"))
+            .send()
+            .await
+        {
             Ok(res) if res.status().is_success() => {
                 return Ok(Json(serde_json::json!({
                     "success": true,
-                    "message": "Local Ministral-3B model ready. llama-server is running."
+                    "message": "Local model ready. llama-server is running."
                 })));
             }
             _ => {

--- a/screensearch-api/src/handlers/system.rs
+++ b/screensearch-api/src/handlers/system.rs
@@ -58,6 +58,228 @@ pub async fn health(State(state): State<Arc<AppState>>) -> Result<Json<HealthRes
     }))
 }
 
+/// One subsystem's startup/readiness state, in plain language for the UI.
+#[derive(Debug, serde::Serialize)]
+pub struct ReadinessStage {
+    /// Stable id: "core" | "search_index" | "answer_generation".
+    pub id: String,
+    /// Short human label.
+    pub label: String,
+    /// State machine value the UI styles on:
+    /// "ready" | "initializing" | "loading" | "downloading" | "needs_setup" | "disabled".
+    /// `initializing`/`loading`/`downloading` are *transitional* — the UI keeps the
+    /// startup banner up while any stage is in one of them.
+    pub state: String,
+    /// One sentence explaining what's happening / what to do.
+    pub detail: String,
+    /// Download progress 0–100 (only for `downloading`).
+    pub progress: Option<f64>,
+    /// Estimated seconds remaining (only for `downloading`).
+    pub eta_seconds: Option<u64>,
+}
+
+/// Aggregated startup readiness across subsystems.
+#[derive(Debug, serde::Serialize)]
+pub struct ReadinessResponse {
+    /// Core (DB + capture/OCR/search) is up — the app is usable for search.
+    pub core_ready: bool,
+    /// No subsystem is still in a transitional (timed) warm-up state.
+    pub all_ready: bool,
+    pub stages: Vec<ReadinessStage>,
+}
+
+fn is_transitional(state: &str) -> bool {
+    matches!(state, "initializing" | "loading" | "downloading")
+}
+
+/// GET /system/readiness
+///
+/// One call the UI polls at startup to explain, in plain language, what the
+/// backend is doing and roughly how long until each capability is usable: core
+/// services (DB/capture/OCR/search), the semantic-search model, and local AI
+/// answer generation (server/model download + load). Designed to be cheap and
+/// non-blocking so it can be polled once a second during warm-up.
+pub async fn get_readiness(State(state): State<Arc<AppState>>) -> Result<Json<ReadinessResponse>> {
+    use screensearch_llm::{get_bin_dir, llama_server_up_to_date, resolve_vision_model};
+
+    let mut stages: Vec<ReadinessStage> = Vec::new();
+
+    // --- Core (database + API + capture/OCR pipeline) ---
+    let core_ready = state.db.get_statistics().await.is_ok();
+    stages.push(ReadinessStage {
+        id: "core".into(),
+        label: "Core services".into(),
+        state: if core_ready { "ready" } else { "initializing" }.into(),
+        detail: if core_ready {
+            "Capture, OCR, and keyword search are running.".into()
+        } else {
+            "Starting the database and capture pipeline…".into()
+        },
+        progress: None,
+        eta_seconds: None,
+    });
+
+    // Tracked downloads (shared by the AI stage's messaging).
+    let downloads = state.get_all_download_progress().await;
+
+    // --- Semantic search (in-process embedding model) ---
+    {
+        let status = state.db.get_embedding_status().await.ok();
+        let indexing_on = status.as_ref().map(|s| s.enabled).unwrap_or(false);
+        let coverage = status.as_ref().map(|s| s.coverage_percent).unwrap_or(0.0);
+        let engine_ready = state.embedding_engine_initialized().await;
+
+        let (st, detail) = if engine_ready {
+            if indexing_on {
+                (
+                    "ready",
+                    format!("Semantic search ready ({coverage:.0}% of frames indexed)."),
+                )
+            } else {
+                (
+                    "ready",
+                    "Search model ready. Enable indexing in Settings → Data & AI for semantic search."
+                        .to_string(),
+                )
+            }
+        } else {
+            (
+                "loading",
+                "Loading the search model — the first run downloads ~450 MB.".to_string(),
+            )
+        };
+        stages.push(ReadinessStage {
+            id: "search_index".into(),
+            label: "Semantic search".into(),
+            state: st.into(),
+            detail,
+            progress: None,
+            eta_seconds: None,
+        });
+    }
+
+    // --- Local AI answer generation (vision + RAG via llama-server) ---
+    {
+        let settings = state.db.get_settings().await.ok();
+        let vision_enabled = settings
+            .as_ref()
+            .map(|s| s.vision_enabled != 0)
+            .unwrap_or(false);
+        let provider = settings
+            .as_ref()
+            .map(|s| s.vision_provider.clone())
+            .unwrap_or_default();
+        let vision_model = settings
+            .as_ref()
+            .map(|s| s.vision_model.clone())
+            .unwrap_or_default();
+
+        let (st, detail, progress, eta): (String, String, Option<f64>, Option<u64>) =
+            if !vision_enabled {
+                (
+                    "disabled".into(),
+                    "Answer Generation is off — turn it on in Settings → Data & AI.".into(),
+                    None,
+                    None,
+                )
+            } else if provider != "local" {
+                (
+                    "ready".into(),
+                    format!("Using your configured provider ({provider})."),
+                    None,
+                    None,
+                )
+            } else if let Some(p) = downloads.get("llama_server") {
+                (
+                    "downloading".into(),
+                    "Downloading the local AI server…".into(),
+                    Some(p.percentage()),
+                    Some(p.eta_seconds),
+                )
+            } else if let Some(p) = downloads.get("llm_model") {
+                (
+                    "downloading".into(),
+                    "Downloading the local AI model…".into(),
+                    Some(p.percentage()),
+                    Some(p.eta_seconds),
+                )
+            } else if !llama_server_up_to_date(&get_bin_dir()) {
+                (
+                    "needs_setup".into(),
+                    "Download the local AI server in Settings → Data & AI.".into(),
+                    None,
+                    None,
+                )
+            } else if resolve_vision_model(&vision_model).is_none() {
+                (
+                    "needs_setup".into(),
+                    "Add a Gemma 4 model and its *mmproj*.gguf to the .models/ folder.".into(),
+                    None,
+                    None,
+                )
+            } else {
+                // Binary + model are present: reflect the server's runtime state.
+                let guard = state.llama_server.read().await;
+                match guard.as_ref() {
+                    Some(server) => {
+                        let status = server.status().await;
+                        match status.as_str() {
+                            "running" => {
+                                let accel = match server.gpu_active().await {
+                                    Some(true) => "GPU (Vulkan)",
+                                    Some(false) => "CPU",
+                                    None => "your device",
+                                };
+                                (
+                                    "ready".into(),
+                                    format!("Local model loaded on {accel}."),
+                                    None,
+                                    None,
+                                )
+                            }
+                            "starting" => (
+                                "loading".into(),
+                                "Loading the model into memory (first request can take a few seconds)…"
+                                    .into(),
+                                None,
+                                None,
+                            ),
+                            _ => (
+                                "ready".into(),
+                                "Ready — the model loads on the first request.".into(),
+                                None,
+                                None,
+                            ),
+                        }
+                    }
+                    None => (
+                        "ready".into(),
+                        "Ready — the model loads on the first request.".into(),
+                        None,
+                        None,
+                    ),
+                }
+            };
+
+        stages.push(ReadinessStage {
+            id: "answer_generation".into(),
+            label: "AI answer generation".into(),
+            state: st,
+            detail,
+            progress,
+            eta_seconds: eta,
+        });
+    }
+
+    let all_ready = core_ready && !stages.iter().any(|s| is_transitional(&s.state));
+
+    Ok(Json(ReadinessResponse {
+        core_ready,
+        all_ready,
+        stages,
+    }))
+}
+
 /// POST /tags - Create a new tag
 ///
 /// Creates a new tag that can be applied to frames.

--- a/screensearch-api/src/handlers/vision.rs
+++ b/screensearch-api/src/handlers/vision.rs
@@ -9,6 +9,7 @@ use crate::error::{AppError, Result};
 use crate::state::AppState;
 use axum::extract::{Path, State};
 use axum::Json;
+use serde::Serialize;
 use std::sync::Arc;
 use tracing::{debug, info};
 
@@ -53,6 +54,78 @@ pub async fn analyze_frame(
         "queue_id": queue_id,
         "already_queued": queue_id == 0,
     })))
+}
+
+/// A locally discovered vision-capable model (a GGUF with a matching `mmproj`
+/// projector beside it) that the user can select for the local provider.
+#[derive(Debug, Serialize)]
+pub struct VisionModelEntry {
+    /// Filename stem, used as the `vision_model` setting value (drives
+    /// `resolve_vision_model`'s preferred match).
+    pub id: String,
+    /// Model GGUF filename (for display).
+    pub model_file: String,
+    /// Projector GGUF filename (for display).
+    pub mmproj_file: String,
+    /// Whether this is the model the server currently resolves to.
+    pub selected: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub struct VisionModelsResponse {
+    pub models: Vec<VisionModelEntry>,
+    /// The id of the currently resolved model, if any.
+    pub selected: Option<String>,
+}
+
+/// GET /api/vision/models
+///
+/// List the locally discovered vision-capable models (each a GGUF paired with an
+/// `mmproj` projector in `.models/`) so the UI can offer a picker for the local
+/// provider. The entry matching the current `vision_model` setting is flagged
+/// `selected`.
+pub async fn list_vision_models(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<VisionModelsResponse>> {
+    let file_name = |p: &std::path::Path| {
+        p.file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string()
+    };
+    let stem = |p: &std::path::Path| {
+        p.file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string()
+    };
+
+    // What the server would actually load given the current setting.
+    let preferred = state
+        .db
+        .get_settings()
+        .await
+        .map(|s| s.vision_model)
+        .unwrap_or_default();
+    let selected_model = screensearch_llm::resolve_vision_model(&preferred).map(|(m, _)| stem(&m));
+
+    let models = screensearch_llm::discover_vision_models()
+        .into_iter()
+        .map(|(model, mmproj)| {
+            let id = stem(&model);
+            VisionModelEntry {
+                selected: Some(&id) == selected_model.as_ref(),
+                model_file: file_name(&model),
+                mmproj_file: file_name(&mmproj),
+                id,
+            }
+        })
+        .collect();
+
+    Ok(Json(VisionModelsResponse {
+        models,
+        selected: selected_model,
+    }))
 }
 
 /// GET /api/vision/status

--- a/screensearch-api/src/routes.rs
+++ b/screensearch-api/src/routes.rs
@@ -43,6 +43,7 @@ pub fn build_router(state: Arc<AppState>) -> Router {
             "/api",
             api_routes
                 .route("/health", get(handlers::system::health))
+                .route("/system/readiness", get(handlers::system::get_readiness))
                 .route("/test-vision", post(handlers::system::test_vision_config))
                 .route("/monitors", get(handlers::system::list_monitors)),
         )
@@ -188,6 +189,7 @@ fn embeddings_routes() -> Router<Arc<AppState>> {
 fn vision_routes() -> Router<Arc<AppState>> {
     Router::new()
         .route("/status", get(handlers::get_vision_status))
+        .route("/models", get(handlers::list_vision_models))
         .route("/analyze/:frame_id", post(handlers::analyze_frame))
 }
 

--- a/screensearch-api/src/state.rs
+++ b/screensearch-api/src/state.rs
@@ -96,9 +96,18 @@ impl AppState {
     }
 
     /// Whether the in-process embedding engine has already been loaded.
-    /// Cheap, non-blocking check that never triggers a model download.
+    ///
+    /// Cheap and truly non-blocking: uses `try_read` so it returns immediately
+    /// even while `get_embedding_engine` holds the write lock across a first-run
+    /// model download/load. A held write lock means initialization is in
+    /// progress, so the engine is not yet ready — report `false` rather than
+    /// blocking (which would hang `GET /embeddings/status` for the whole
+    /// download and freeze the Settings card on its loading skeleton).
     pub async fn embedding_engine_initialized(&self) -> bool {
-        self.embedding_engine.read().await.is_some()
+        match self.embedding_engine.try_read() {
+            Ok(guard) => guard.is_some(),
+            Err(_) => false,
+        }
     }
 
     /// Get or initialize the embedding engine

--- a/screensearch-db/src/db.rs
+++ b/screensearch-db/src/db.rs
@@ -57,7 +57,13 @@ impl DatabaseManager {
             config.min_connections
         );
 
-        // Create SQLite connection options
+        // Create SQLite connection options.
+        //
+        // `busy_timeout` is essential: in WAL mode writers still serialize, so a
+        // concurrent write (e.g. the vision worker storing an analysis result
+        // while the capture/OCR pipeline inserts a frame) would otherwise return
+        // `SQLITE_BUSY` ("database is locked") immediately. With a busy timeout
+        // the writer waits for the lock instead of erroring.
         let options = SqliteConnectOptions::from_str(&format!("sqlite:{}", config.path))
             .map_err(|e| {
                 crate::DatabaseError::InitializationError(format!(
@@ -65,7 +71,8 @@ impl DatabaseManager {
                     e
                 ))
             })?
-            .create_if_missing(true);
+            .create_if_missing(true)
+            .busy_timeout(Duration::from_secs(10));
 
         // Create connection pool with configured limits
         let pool = SqlitePoolOptions::new()

--- a/screensearch-db/src/migrations.rs
+++ b/screensearch-db/src/migrations.rs
@@ -58,6 +58,12 @@ pub async fn run_migrations(pool: &Pool<Sqlite>) -> Result<()> {
         MIGRATION_010_UNIQUE_EMBEDDING_CHUNKS,
     )
     .await?;
+    apply_migration(
+        pool,
+        "011_gemma4_vision_default",
+        MIGRATION_011_GEMMA4_VISION_DEFAULT,
+    )
+    .await?;
 
     tracing::info!("All migrations completed successfully");
     Ok(())
@@ -418,6 +424,17 @@ UPDATE settings SET
     vision_model = 'ministral-3:3b',
     vision_endpoint = 'http://127.0.0.1:31130'
 WHERE id = 1;
+"#;
+
+/// Migration 011 - Switch the default local generation/vision model from the
+/// text-only Ministral-3B to Gemma 4 E4B (multimodal). The previous default
+/// could not answer vision (image) requests, so enabling Answer Generation
+/// produced "image input is not supported" errors. Only rows still carrying the
+/// old `ministral-3:3b` default are migrated, so a user who deliberately picked
+/// another model is left untouched.
+const MIGRATION_011_GEMMA4_VISION_DEFAULT: &str = r#"
+UPDATE settings SET vision_model = 'gemma-4-E4B'
+WHERE vision_model = 'ministral-3:3b' OR vision_model IS NULL;
 "#;
 
 /// Migration 008 - Performance Indexes

--- a/screensearch-embeddings/src/lib.rs
+++ b/screensearch-embeddings/src/lib.rs
@@ -95,7 +95,9 @@ impl Default for EmbeddingConfig {
         Self {
             model: MODEL_NAME.to_string(),
             model_version: MODEL_VERSION.to_string(),
-            batch_size: 16,
+            // Larger batch = better throughput when indexing a backlog of frames
+            // (the on-demand "Process frames" job batches chunks across frames).
+            batch_size: 32,
             cache_dir: std::env::var_os("SCREENSEARCH_MODEL_CACHE").map(PathBuf::from),
             show_download_progress: true,
             reranker_enabled: false,
@@ -111,7 +113,7 @@ mod tests {
     #[test]
     fn test_config_defaults() {
         let config = EmbeddingConfig::default();
-        assert_eq!(config.batch_size, 16);
+        assert_eq!(config.batch_size, 32);
         assert_eq!(config.model, MODEL_NAME);
         assert!(!config.reranker_enabled);
     }

--- a/screensearch-llm/src/download.rs
+++ b/screensearch-llm/src/download.rs
@@ -277,6 +277,7 @@ pub fn discover_local_models() -> Vec<PathBuf> {
                         .extension()
                         .and_then(|ext| ext.to_str())
                         .is_some_and(|ext| ext.eq_ignore_ascii_case("gguf"))
+                    && is_loadable_model_gguf(path)
             })
             // Canonicalize so the same physical file reached via different
             // search dirs (e.g. relative `.models` and an absolute exe-dir
@@ -351,6 +352,91 @@ fn token_overlap(a_lower: &str, b_lower: &str) -> usize {
         .filter(|t| !t.is_empty())
         .filter(|t| a.contains(t))
         .count()
+}
+
+/// Minimum size for a file to be treated as a loadable *primary* model. Filters
+/// out helper GGUFs that live beside real models (e.g. a ~59 MB multi-token
+/// prediction head, `mtp-*.gguf`) so they are never loaded as the generation or
+/// vision model.
+const MODEL_MIN_SIZE_BYTES: u64 = 500_000_000;
+
+/// Whether a GGUF path is a loadable *primary* model — not a multimodal
+/// projector, not a non-standalone helper head (`mtp-*`), and large enough to be
+/// a real model. Projectors are discovered and paired separately via
+/// [`resolve_mmproj_for`].
+fn is_loadable_model_gguf(path: &Path) -> bool {
+    if is_mmproj_file(path) {
+        return false;
+    }
+    let name = path
+        .file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.to_ascii_lowercase())
+        .unwrap_or_default();
+    // `mtp-*` is a multi-token-prediction head shipped beside Gemma 4 models,
+    // not a model that can be loaded on its own.
+    if name.starts_with("mtp-") {
+        return false;
+    }
+    match std::fs::metadata(path) {
+        Ok(meta) => meta.len() >= MODEL_MIN_SIZE_BYTES,
+        Err(_) => false,
+    }
+}
+
+/// The quantization level (the digit in a `q2`..`q8` token) of a lowercased
+/// filename stem, if present. E.g. `...-q4_k_xl` and `...q4_0...` both → 4.
+fn quant_level(stem_lower: &str) -> Option<u8> {
+    stem_lower
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .find_map(|tok| {
+            let b = tok.as_bytes();
+            if b.len() == 2 && b[0] == b'q' && b[1].is_ascii_digit() {
+                Some(b[1] - b'0')
+            } else {
+                None
+            }
+        })
+}
+
+/// Desirability score for a model's quantization for continuous on-device use:
+/// Q4 is the sweet spot (quality vs. speed/VRAM); higher quants trade speed for
+/// marginal quality; Q2/Q3 are penalised so a low-quality quant is only picked
+/// when nothing better sits beside it. Unknown/unquantized → neutral.
+fn quant_desirability(stem_lower: &str) -> u32 {
+    match quant_level(stem_lower) {
+        Some(4) => 100,
+        Some(5) => 90,
+        Some(6) => 80,
+        Some(8) => 70,
+        Some(7) => 60,
+        Some(3) => 40,
+        Some(2) => 30,
+        Some(0 | 1) => 25,
+        Some(_) => 50,
+        None => 50,
+    }
+}
+
+/// From vision-model candidates (in stable discovery order), pick the one with
+/// the best quantization, preferring the earliest on ties.
+fn pick_best_quant<'a>(
+    candidates: impl Iterator<Item = &'a (PathBuf, PathBuf)>,
+) -> Option<&'a (PathBuf, PathBuf)> {
+    let mut best: Option<(&'a (PathBuf, PathBuf), u32)> = None;
+    for cand in candidates {
+        let score = cand
+            .0
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| quant_desirability(&s.to_ascii_lowercase()))
+            .unwrap_or(50);
+        // Strictly-greater so the first candidate on a tie wins (stable order).
+        if best.map(|(_, b)| score > b).unwrap_or(true) {
+            best = Some((cand, score));
+        }
+    }
+    best.map(|(c, _)| c)
 }
 
 /// Whether a GGUF filename is a multimodal projector (its name contains
@@ -433,10 +519,11 @@ pub fn discover_vision_models() -> Vec<(PathBuf, PathBuf)> {
 
 /// Resolve the vision model + projector to run for the unified local server.
 ///
-/// Selection order:
-/// 1. A discovered vision model whose filename matches `preferred` (the
+/// Selection order (within each tier, the best quantization wins — see
+/// [`quant_desirability`] — so a Q4 is chosen over a Q2 sitting beside it):
+/// 1. Discovered vision models whose filename matches `preferred` (the
 ///    `vision_model` setting), in either direction (substring).
-/// 2. A Gemma-4 **E4B** model — the unified default (small + fast).
+/// 2. Gemma-4 **E4B** models — the unified default (small + fast).
 /// 3. The first vision-capable model discovered.
 ///
 /// Returns `None` when no local model has a projector beside it.
@@ -446,27 +533,28 @@ pub fn resolve_vision_model(preferred: &str) -> Option<(PathBuf, PathBuf)> {
         return None;
     }
 
+    let stem_lower = |m: &Path| {
+        m.file_stem()
+            .and_then(|s| s.to_str())
+            .map(|s| s.to_ascii_lowercase())
+    };
+
     let pref = preferred.trim().to_ascii_lowercase();
     if !pref.is_empty() {
-        if let Some(found) = models.iter().find(|(m, _)| {
-            m.file_stem()
-                .and_then(|s| s.to_str())
-                .map(|s| {
-                    let s = s.to_ascii_lowercase();
-                    s.contains(&pref) || pref.contains(&s)
-                })
+        let matches = models.iter().filter(|(m, _)| {
+            stem_lower(m)
+                .map(|s| s.contains(&pref) || pref.contains(&s))
                 .unwrap_or(false)
-        }) {
+        });
+        if let Some(found) = pick_best_quant(matches) {
             return Some(found.clone());
         }
     }
 
-    if let Some(found) = models.iter().find(|(m, _)| {
-        m.file_stem()
-            .and_then(|s| s.to_str())
-            .map(|s| s.to_ascii_lowercase().contains("e4b"))
-            .unwrap_or(false)
-    }) {
+    let e4b = models
+        .iter()
+        .filter(|(m, _)| stem_lower(m).map(|s| s.contains("e4b")).unwrap_or(false));
+    if let Some(found) = pick_best_quant(e4b) {
         return Some(found.clone());
     }
 
@@ -1014,5 +1102,52 @@ mod tests {
                 Some("gguf".to_string())
             );
         }
+    }
+
+    #[test]
+    fn test_quant_level_and_desirability() {
+        assert_eq!(quant_level("gemma-4-e4b-it-qat-ud-q4_k_xl"), Some(4));
+        assert_eq!(quant_level("gemma-4-e4b_q4_0-it"), Some(4));
+        assert_eq!(quant_level("gemma-4-e4b-it-qat-ud-q2_k_xl"), Some(2));
+        assert_eq!(quant_level("some-model-no-quant"), None);
+        // Q4 is the sweet spot: preferred over a low quant and over a heavier one.
+        assert!(quant_desirability("m-q4_k_xl") > quant_desirability("m-q2_k_xl"));
+        assert!(quant_desirability("m-q4_k_xl") > quant_desirability("m-q8_0"));
+    }
+
+    #[test]
+    fn test_pick_best_quant_prefers_q4_first_on_tie() {
+        let mk = |m: &str| {
+            (
+                PathBuf::from(format!("{m}.gguf")),
+                PathBuf::from("mmproj.gguf"),
+            )
+        };
+        let q2 = mk("gemma-4-E4B-it-qat-UD-Q2_K_XL");
+        let q4xl = mk("gemma-4-E4B-it-qat-UD-Q4_K_XL");
+        let q4_0 = mk("gemma-4-E4B_q4_0-it");
+        let cands = vec![q2, q4xl.clone(), q4_0];
+        // Q4 beats Q2; on the Q4 tie the earliest (Q4_K_XL) wins.
+        assert_eq!(pick_best_quant(cands.iter()), Some(&q4xl));
+    }
+
+    #[test]
+    fn test_is_loadable_model_gguf_excludes_helpers() {
+        let dir = std::env::temp_dir().join("ss_loadable_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let mtp = dir.join("mtp-gemma-4-E4B-it.gguf");
+        let mmproj = dir.join("gemma-4-E4B-it-mmproj.gguf");
+        let partial = dir.join("gemma-4-E4B_q4_0-it.gguf");
+        for f in [&mtp, &mmproj, &partial] {
+            std::fs::write(f, b"x").unwrap();
+        }
+        // mtp heads and projectors are never primary models.
+        assert!(!is_loadable_model_gguf(&mtp));
+        assert!(!is_loadable_model_gguf(&mmproj));
+        // A real model name but below the size floor (e.g. a truncated download)
+        // is also rejected.
+        assert!(!is_loadable_model_gguf(&partial));
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/screensearch-llm/src/server.rs
+++ b/screensearch-llm/src/server.rs
@@ -373,16 +373,38 @@ impl LlamaServer {
 
         // Capture llama-server's stdout/stderr to a log file so Vulkan init,
         // the GPU layer-offload summary, and any silent GPU→CPU fallback are
-        // observable (previously sent to /dev/null, which hid all of it). Falls
+        // observable (previously sent to /dev/null, which hid all of it).
+        //
+        // Open in *append* mode (not truncate): when GPU mode fails and CPU mode
+        // is retried, this runs twice — truncating would wipe the GPU failure
+        // output that explains the fallback. A header marks each attempt. Falls
         // back to discarding output only if the log file can't be opened.
         let log_path = get_bin_dir().join("llama-server.log");
-        match std::fs::File::create(&log_path) {
-            Ok(out) => {
-                let err = out.try_clone().unwrap_or_else(|_| {
-                    std::fs::File::create(&log_path).expect("re-open llama-server log")
-                });
-                cmd.stdout(Stdio::from(out));
-                cmd.stderr(Stdio::from(err));
+        match std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&log_path)
+        {
+            Ok(mut file) => {
+                use std::io::Write;
+                let _ = writeln!(
+                    file,
+                    "\n=== llama-server start: {} mode (port {}) ===",
+                    if use_gpu { "GPU (Vulkan)" } else { "CPU" },
+                    port
+                );
+                match file.try_clone() {
+                    Ok(err_file) => {
+                        cmd.stdout(Stdio::from(file));
+                        cmd.stderr(Stdio::from(err_file));
+                    }
+                    // Couldn't duplicate the handle: keep stdout on the log,
+                    // discard stderr rather than panicking.
+                    Err(_) => {
+                        cmd.stdout(Stdio::from(file));
+                        cmd.stderr(Stdio::null());
+                    }
+                }
             }
             Err(e) => {
                 warn!(

--- a/screensearch-llm/src/server.rs
+++ b/screensearch-llm/src/server.rs
@@ -33,8 +33,27 @@ const MAX_RESTART_ATTEMPTS: u32 = 3;
 /// Health check timeout for CPU mode (model loading can take 60-90s on slower systems)
 const HEALTH_CHECK_TIMEOUT_SECS: u64 = 120;
 
-/// Health check timeout for GPU mode (shorter to allow faster fallback)
-const GPU_HEALTH_CHECK_TIMEOUT_SECS: u64 = 45;
+/// GPU health-check timeout is scaled by model size: loading a multi-GB model
+/// plus a ~1 GB vision projector into VRAM over Vulkan (with first-run shader
+/// compilation) routinely takes longer than a fixed short timeout. A timeout
+/// that is too aggressive caused a silent, false fallback to CPU — the root of
+/// "answer generation does not use the GPU". Base + per-GB, capped.
+const GPU_HEALTH_CHECK_BASE_SECS: u64 = 60;
+const GPU_HEALTH_CHECK_SECS_PER_GB: u64 = 25;
+const GPU_HEALTH_CHECK_MAX_SECS: u64 = 300;
+
+/// Compute the GPU-mode health-check timeout from the on-disk size of the model
+/// (and projector, if any). Falls back to the base timeout when sizes are
+/// unknown.
+fn gpu_health_timeout_secs(config: &LlamaServerConfig) -> u64 {
+    let size_of = |p: &std::path::Path| std::fs::metadata(p).map(|m| m.len()).unwrap_or(0);
+    let mut bytes = size_of(&config.model_path);
+    if let Some(mmproj) = &config.mmproj_path {
+        bytes += size_of(mmproj);
+    }
+    let gb = bytes / 1_000_000_000;
+    (GPU_HEALTH_CHECK_BASE_SECS + GPU_HEALTH_CHECK_SECS_PER_GB * gb).min(GPU_HEALTH_CHECK_MAX_SECS)
+}
 
 /// Health check poll interval
 const HEALTH_CHECK_POLL_MS: u64 = 1000;
@@ -119,6 +138,10 @@ pub struct LlamaServer {
     last_request: RwLock<Instant>,
     /// Number of restart attempts
     restart_count: RwLock<u32>,
+    /// Which acceleration mode the running server actually started in:
+    /// `Some(true)` = GPU (Vulkan), `Some(false)` = CPU fallback, `None` = not
+    /// running. Surfaced to the UI so a silent CPU fallback is visible.
+    gpu_active: RwLock<Option<bool>>,
     /// Flag to signal shutdown
     shutting_down: AtomicBool,
     /// Lock to serialize start attempts (prevents race condition)
@@ -138,6 +161,7 @@ impl LlamaServer {
             active_port: RwLock::new(port),
             last_request: RwLock::new(Instant::now()),
             restart_count: RwLock::new(0),
+            gpu_active: RwLock::new(None),
             shutting_down: AtomicBool::new(false),
             starting_lock: tokio::sync::Mutex::new(()),
             client: reqwest::Client::builder()
@@ -189,6 +213,12 @@ impl LlamaServer {
     /// Update idle TTL
     pub async fn set_idle_ttl(&self, ttl: Duration) {
         self.config.write().await.idle_ttl = ttl;
+    }
+
+    /// Which acceleration mode the running server started in: `Some(true)` =
+    /// GPU (Vulkan), `Some(false)` = CPU, `None` = not currently running.
+    pub async fn gpu_active(&self) -> Option<bool> {
+        *self.gpu_active.read().await
     }
 
     /// Start the server if not already running.
@@ -263,6 +293,7 @@ impl LlamaServer {
                         "llama-server started successfully with GPU on port {}",
                         port
                     );
+                    *self.gpu_active.write().await = Some(true);
                     return Ok(());
                 }
                 Err(e) => {
@@ -288,6 +319,7 @@ impl LlamaServer {
                     "llama-server started successfully with CPU on port {}",
                     port
                 );
+                *self.gpu_active.write().await = Some(false);
                 Ok(())
             }
             Err(e) => {
@@ -339,9 +371,28 @@ impl LlamaServer {
             cmd.arg("-t").arg(config.threads.to_string());
         }
 
-        // Redirect stdout/stderr to null to avoid blocking
-        cmd.stdout(Stdio::null());
-        cmd.stderr(Stdio::null());
+        // Capture llama-server's stdout/stderr to a log file so Vulkan init,
+        // the GPU layer-offload summary, and any silent GPU→CPU fallback are
+        // observable (previously sent to /dev/null, which hid all of it). Falls
+        // back to discarding output only if the log file can't be opened.
+        let log_path = get_bin_dir().join("llama-server.log");
+        match std::fs::File::create(&log_path) {
+            Ok(out) => {
+                let err = out.try_clone().unwrap_or_else(|_| {
+                    std::fs::File::create(&log_path).expect("re-open llama-server log")
+                });
+                cmd.stdout(Stdio::from(out));
+                cmd.stderr(Stdio::from(err));
+            }
+            Err(e) => {
+                warn!(
+                    "Could not open llama-server log at {:?} ({}); discarding output",
+                    log_path, e
+                );
+                cmd.stdout(Stdio::null());
+                cmd.stderr(Stdio::null());
+            }
+        }
 
         // Spawn the process
         let child = cmd.spawn().map_err(|e| {
@@ -367,9 +418,10 @@ impl LlamaServer {
 
         *self.child.lock().await = Some(child);
 
-        // Use shorter timeout for GPU mode to allow faster fallback
+        // GPU mode: scale the timeout by model size so a large model loading
+        // into VRAM isn't mistaken for a GPU failure and bounced to CPU.
         let timeout_secs = if use_gpu {
-            GPU_HEALTH_CHECK_TIMEOUT_SECS
+            gpu_health_timeout_secs(config)
         } else {
             HEALTH_CHECK_TIMEOUT_SECS
         };
@@ -442,6 +494,7 @@ impl LlamaServer {
         }
 
         *self.status.write().await = ServerStatus::Stopped;
+        *self.gpu_active.write().await = None;
         info!("llama-server stopped");
         Ok(())
     }
@@ -453,6 +506,7 @@ impl LlamaServer {
             let _ = child.kill().await;
         }
         *self.status.write().await = ServerStatus::Stopped;
+        *self.gpu_active.write().await = None;
     }
 
     /// Shutdown the server and prevent restarts

--- a/screensearch-ui/src/App.tsx
+++ b/screensearch-ui/src/App.tsx
@@ -13,6 +13,7 @@ import { FrameModal } from './components/FrameModal';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { Footer } from './components/Footer';
 import { DownloadProgress } from './components/DownloadProgress';
+import { StartupStatus } from './components/StartupStatus';
 import { Loader2 } from 'lucide-react';
 
 // Lazy load heavy pages for better initial bundle size
@@ -116,6 +117,7 @@ function AppContent() {
       <SettingsPanel />
       <FrameModal />
       <SearchInvite isOpen={isSearchModalOpen} onClose={closeSearchModal} />
+      <StartupStatus />
       <DownloadProgress />
 
       <Toaster

--- a/screensearch-ui/src/components/AiSettings.tsx
+++ b/screensearch-ui/src/components/AiSettings.tsx
@@ -6,7 +6,7 @@ import { toast } from 'react-hot-toast';
 
 // Provider options
 const PROVIDER_OPTIONS = [
-    { value: 'local', label: 'Bundled Ministral-3-3B', description: 'Optional local model for answers and reports; not used for OCR or retrieval' },
+    { value: 'local', label: 'Bundled Gemma 4 E4B (vision)', description: 'Optional on-device model for answers, reports, and screenshot understanding; not used for OCR or retrieval' },
     { value: 'http://localhost:11434/v1', label: 'Ollama-compatible', description: 'Local generation server on port 11434' },
     { value: 'custom', label: 'OpenAI-compatible', description: 'Remote or local generation endpoint' },
 ] as const;
@@ -94,7 +94,7 @@ export function AiSettings() {
                     <div className="flex items-center gap-3 p-4 bg-paper-2 border border-rule rounded-none">
                         <Cpu className="w-8 h-8 text-ink flex-shrink-0" />
                         <div>
-                            <p className="font-serif text-[15px]">Ministral-3-3B (Bundled Generation)</p>
+                            <p className="font-serif text-[15px]">Gemma 4 E4B (Bundled, on-device vision + text)</p>
                             <p className="text-xs font-serif italic text-muted">
                                 GPU-accelerated via Vulkan. Works on NVIDIA, AMD, and Intel GPUs.
                                 Model runs entirely on your machine - no API key required.

--- a/screensearch-ui/src/components/AnswerCard.tsx
+++ b/screensearch-ui/src/components/AnswerCard.tsx
@@ -49,7 +49,7 @@ export function AnswerCard() {
                     <div className="flex-1 space-y-4">
                         <div className="flex items-center gap-2 text-primary">
                             <Sparkles className="h-5 w-5" />
-                            <h3 className="font-semibold">AI Intelligence</h3>
+                            <h3 className="font-semibold">AI Insights</h3>
                         </div>
 
                         {!answer && !loading && !error && (

--- a/screensearch-ui/src/components/EmbeddingsStatus.tsx
+++ b/screensearch-ui/src/components/EmbeddingsStatus.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Brain, RefreshCw, Check, X, AlertTriangle, Download } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 
@@ -24,28 +24,48 @@ export function EmbeddingsStatus() {
     const [generating, setGenerating] = useState(false);
     const [preparingModels, setPreparingModels] = useState(false);
     const [selectedPercentage, setSelectedPercentage] = useState<25 | 50 | 100>(50);
+    // Interval used to poll status while a background indexing job runs.
+    const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-    const fetchStatus = async () => {
+    const fetchStatus = async (): Promise<EmbeddingStatus | null> => {
+        // Abort after 8s so a slow/stuck backend never freezes the card on its
+        // loading skeleton — fall through to the error+retry UI instead.
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 8000);
         try {
             setLoading(true);
-            const response = await fetch('/api/embeddings/status');
+            const response = await fetch('/api/embeddings/status', { signal: controller.signal });
             if (response.ok) {
                 const data = await response.json();
                 setStatus(data);
                 setLoadError(null);
+                return data as EmbeddingStatus;
             } else {
                 setLoadError(`Status request failed (${response.status})`);
             }
         } catch (error) {
             console.error('Failed to fetch embedding status:', error);
-            setLoadError(error instanceof Error ? error.message : 'Failed to load status');
+            const aborted = error instanceof DOMException && error.name === 'AbortError';
+            setLoadError(
+                aborted
+                    ? 'AI status request timed out'
+                    : error instanceof Error
+                        ? error.message
+                        : 'Failed to load status'
+            );
         } finally {
+            clearTimeout(timer);
             setLoading(false);
         }
+        return null;
     };
 
     useEffect(() => {
         fetchStatus();
+        // Clear any polling interval on unmount.
+        return () => {
+            if (pollRef.current) clearInterval(pollRef.current);
+        };
     }, []);
 
     const toggleEnabled = async () => {
@@ -80,16 +100,36 @@ export function EmbeddingsStatus() {
                 body: JSON.stringify({ batch_size: batchSize }),
             });
             const data = await response.json();
-            if (response.ok && data.success) {
-                await fetchStatus();
-                toast.success(data.message);
-            } else {
+            if (!response.ok || !data.success) {
                 toast.error(data.message || data.error || "Failed to start generation");
+                setGenerating(false);
+                return;
             }
+
+            toast.success(data.message);
+            // The job runs in the background; poll status so the coverage bar
+            // climbs as frames finish. Keep `generating` true (buttons disabled,
+            // spinner shown) until the backlog drains or a safety cap is hit.
+            await fetchStatus();
+            if (pollRef.current) clearInterval(pollRef.current);
+            const startedAt = Date.now();
+            pollRef.current = setInterval(async () => {
+                const latest = await fetchStatus();
+                const remaining = latest
+                    ? latest.total_frames - latest.frames_with_embeddings
+                    : 0;
+                if (!latest || remaining <= 0 || Date.now() - startedAt > 600000) {
+                    if (pollRef.current) {
+                        clearInterval(pollRef.current);
+                        pollRef.current = null;
+                    }
+                    setGenerating(false);
+                    if (latest && remaining <= 0) toast.success('Indexing complete');
+                }
+            }, 3000);
         } catch (error) {
             console.error('Failed to trigger generation:', error);
             toast.error("Failed to trigger generation");
-        } finally {
             setGenerating(false);
         }
     };

--- a/screensearch-ui/src/components/ReportGenerator.tsx
+++ b/screensearch-ui/src/components/ReportGenerator.tsx
@@ -65,11 +65,11 @@ export function ReportGenerator() {
     const handleSave = () => {
         if (!report) return;
 
-        // Format: intelligence-report-{type}-{YYYY-MM-DD}-{HH-MM}.md
+        // Format: insights-report-{type}-{YYYY-MM-DD}-{HH-MM}.md
         const now = new Date();
         const dateStr = now.toISOString().split('T')[0]; // YYYY-MM-DD
         const timeStr = (now.toISOString().split('T')[1] ?? '00:00').substring(0, 5).replace(':', '-'); // HH-MM
-        const filename = `intelligence-report-${generatedReportType}-${dateStr}-${timeStr}.md`;
+        const filename = `insights-report-${generatedReportType}-${dateStr}-${timeStr}.md`;
 
         const blob = new Blob([report], { type: 'text/markdown' });
         const url = URL.createObjectURL(blob);
@@ -88,7 +88,7 @@ export function ReportGenerator() {
             <div className="bg-card border border-border rounded-lg p-6 space-y-6">
                 <div className="flex items-center gap-2 pb-4 border-b border-border">
                     <Sparkles className="w-5 h-5 text-primary" />
-                    <h2 className="text-lg font-semibold">Generate Intelligence Report</h2>
+                    <h2 className="text-lg font-semibold">Generate Insights Report</h2>
                 </div>
 
                 <div className="space-y-4">
@@ -141,7 +141,7 @@ export function ReportGenerator() {
                     <div className="flex items-center justify-between p-4 border-b border-border bg-muted/30">
                         <div className="flex items-center gap-2">
                             <FileText className="w-5 h-5 text-primary" />
-                            <h3 className="text-lg font-semibold">Intelligence Report</h3>
+                            <h3 className="text-lg font-semibold">Insights Report</h3>
                         </div>
                         <div className="flex items-center gap-2">
                             <button

--- a/screensearch-ui/src/components/SettingsPanel.tsx
+++ b/screensearch-ui/src/components/SettingsPanel.tsx
@@ -124,7 +124,7 @@ export function SettingsPanel() {
   const { data: visionModels, refetch: refetchVisionModels } = useQuery<VisionModelsResponse>({
     queryKey: ['vision-models'],
     queryFn: async () => {
-      const res = await fetch('http://localhost:3131/api/vision/models');
+      const res = await fetch('/api/vision/models');
       if (!res.ok) throw new Error('Failed to fetch vision models');
       return res.json();
     },
@@ -676,6 +676,7 @@ export function SettingsPanel() {
                           vision_provider: visionProvider,
                           vision_model: visionModel,
                           vision_endpoint: visionEndpoint,
+                          vision_api_key: visionApiKey,
                         });
                       }}
                       className={cn(

--- a/screensearch-ui/src/components/SettingsPanel.tsx
+++ b/screensearch-ui/src/components/SettingsPanel.tsx
@@ -42,6 +42,20 @@ interface ServerStatus {
   idle_seconds: number;
   model_loaded: boolean;
   server_binary_available: boolean;
+  // 'gpu' (Vulkan), 'cpu', or 'unknown' when not running.
+  acceleration?: 'gpu' | 'cpu' | 'unknown';
+}
+
+// A locally discovered vision-capable model (GGUF + mmproj pair) the user can pick.
+interface VisionModelEntry {
+  id: string;
+  model_file: string;
+  mmproj_file: string;
+  selected: boolean;
+}
+interface VisionModelsResponse {
+  models: VisionModelEntry[];
+  selected: string | null;
 }
 
 // Format idle time for display
@@ -104,6 +118,17 @@ export function SettingsPanel() {
       if (status === 'running') return 5000;
       return false;
     },
+  });
+
+  // Locally discovered vision models (GGUF + mmproj pairs) for the picker.
+  const { data: visionModels, refetch: refetchVisionModels } = useQuery<VisionModelsResponse>({
+    queryKey: ['vision-models'],
+    queryFn: async () => {
+      const res = await fetch('http://localhost:3131/api/vision/models');
+      if (!res.ok) throw new Error('Failed to fetch vision models');
+      return res.json();
+    },
+    enabled: isSettingsPanelOpen,
   });
 
   // Server control mutations
@@ -206,7 +231,7 @@ export function SettingsPanel() {
   const [retentionDays, setRetentionDays] = useState(30);
   const [visionEnabled, setVisionEnabled] = useState(false);
   const [visionProvider, setVisionProvider] = useState('local');
-  const [visionModel, setVisionModel] = useState('ministral-3:3b');
+  const [visionModel, setVisionModel] = useState('gemma-4-E4B');
   const [visionEndpoint, setVisionEndpoint] = useState('http://127.0.0.1:31130');
   const [visionApiKey, setVisionApiKey] = useState('');
   const [newExcludedApp, setNewExcludedApp] = useState('');
@@ -221,7 +246,7 @@ export function SettingsPanel() {
       setRetentionDays(Number(apiSettings.retention_days));
       setVisionEnabled(apiSettings.vision_enabled === 1);
       setVisionProvider(apiSettings.vision_provider || 'local');
-      setVisionModel(apiSettings.vision_model || 'ministral-3:3b');
+      setVisionModel(apiSettings.vision_model || 'gemma-4-E4B');
       setVisionEndpoint(apiSettings.vision_endpoint || 'http://127.0.0.1:31130');
       setVisionApiKey(apiSettings.vision_api_key || '');
     }
@@ -591,7 +616,7 @@ export function SettingsPanel() {
                 </section>
 
                 <section className="space-y-4">
-                  <h3 className="text-lg font-semibold border-b border-border pb-2">AI & Intelligence</h3>
+                  <h3 className="text-lg font-semibold border-b border-border pb-2">AI & Insights</h3>
 
                   <div className="p-4 bg-card rounded-xl border border-border space-y-4">
                     <div>
@@ -727,6 +752,52 @@ export function SettingsPanel() {
                               )}
                             </div>
 
+                            {/* Vision Model Picker — discovered (model + mmproj) pairs in .models/ */}
+                            <div className="space-y-2">
+                              <label className="block text-sm font-medium">Vision model</label>
+                              {visionModels && visionModels.models.length > 0 ? (
+                                <>
+                                  <select
+                                    value={visionModels.selected ?? ''}
+                                    onChange={(e) => {
+                                      const id = e.target.value;
+                                      setVisionModel(id);
+                                      updateSettings.mutate(
+                                        {
+                                          capture_interval: captureInterval,
+                                          monitors: JSON.stringify(monitors),
+                                          excluded_apps: JSON.stringify(excludedApps),
+                                          is_paused: isPaused ? 1 : 0,
+                                          retention_days: retentionDays,
+                                          vision_enabled: visionEnabled ? 1 : 0,
+                                          vision_provider: visionProvider,
+                                          vision_model: id,
+                                          vision_endpoint: visionEndpoint,
+                                          vision_api_key: visionApiKey,
+                                        },
+                                        { onSuccess: () => { refetchVisionModels(); refetchServerStatus(); } }
+                                      );
+                                    }}
+                                    className="w-full bg-background border border-input rounded-lg px-3 py-2 font-mono text-sm"
+                                  >
+                                    {visionModels.models.map((m) => (
+                                      <option key={m.id} value={m.id}>{m.model_file}</option>
+                                    ))}
+                                  </select>
+                                  <p className="text-xs text-muted-foreground">
+                                    Paired projector: {visionModels.models.find((m) => m.id === visionModels.selected)?.mmproj_file ?? '—'}.
+                                    Changing the model restarts the local server on the next request.
+                                  </p>
+                                </>
+                              ) : (
+                                <p className="text-xs text-muted-foreground">
+                                  No vision-capable model found. Drop a Gemma&nbsp;4 GGUF and its matching
+                                  <code className="mx-1 px-1 rounded bg-secondary/60">*mmproj*.gguf</code>
+                                  into <code className="px-1 rounded bg-secondary/60">.models/</code>, then reopen settings.
+                                </p>
+                              )}
+                            </div>
+
                             {/* Divider */}
                             <div className="h-px bg-border/50" />
 
@@ -785,7 +856,12 @@ export function SettingsPanel() {
                                   {serverStatus.status === 'running' && (
                                     <div className="text-xs text-muted-foreground space-y-1">
                                       <p>Idle: {formatIdleTime(serverStatus.idle_seconds)}</p>
-                                      {serverStatus.model_loaded && <p className="text-green-500">Model loaded in VRAM</p>}
+                                      {serverStatus.acceleration === 'gpu' && (
+                                        <p className="text-green-500">Running on GPU (Vulkan) — model offloaded to VRAM</p>
+                                      )}
+                                      {serverStatus.acceleration === 'cpu' && (
+                                        <p className="text-yellow-500">Running on CPU — no GPU offload. See bin/llama-server.log for the Vulkan reason.</p>
+                                      )}
                                     </div>
                                   )}
 

--- a/screensearch-ui/src/components/StartupStatus.tsx
+++ b/screensearch-ui/src/components/StartupStatus.tsx
@@ -78,7 +78,10 @@ export function StartupStatus() {
         enabled: !dismissed,
         // Poll while warming up; stop once everything is ready.
         refetchInterval: (query) => (query.state.data?.all_ready ? false : 1500),
-        retry: true,
+        // Local endpoint: retry quickly during the brief window before the API
+        // binds, rather than the default long exponential backoff.
+        retry: 3,
+        retryDelay: 500,
     });
 
     useEffect(() => {

--- a/screensearch-ui/src/components/StartupStatus.tsx
+++ b/screensearch-ui/src/components/StartupStatus.tsx
@@ -1,0 +1,188 @@
+import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { Loader2, CheckCircle2, Download, AlertCircle, CircleDashed, X } from 'lucide-react';
+
+type StageState =
+    | 'ready'
+    | 'initializing'
+    | 'loading'
+    | 'downloading'
+    | 'needs_setup'
+    | 'disabled';
+
+interface ReadinessStage {
+    id: string;
+    label: string;
+    state: StageState;
+    detail: string;
+    progress?: number | null;
+    eta_seconds?: number | null;
+}
+
+interface ReadinessResponse {
+    core_ready: boolean;
+    all_ready: boolean;
+    stages: ReadinessStage[];
+}
+
+function formatEta(seconds?: number | null): string {
+    if (seconds == null || seconds <= 0) return '';
+    if (seconds < 60) return `${seconds}s left`;
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return s > 0 ? `${m}m ${s}s left` : `${m}m left`;
+}
+
+function StageIcon({ state }: { state: StageState }) {
+    switch (state) {
+        case 'ready':
+            return <CheckCircle2 className="h-4 w-4 text-green-500 flex-shrink-0" />;
+        case 'downloading':
+            return <Download className="h-4 w-4 text-primary flex-shrink-0 animate-pulse" />;
+        case 'initializing':
+        case 'loading':
+            return <Loader2 className="h-4 w-4 text-primary flex-shrink-0 animate-spin" />;
+        case 'needs_setup':
+            return <AlertCircle className="h-4 w-4 text-amber-500 flex-shrink-0" />;
+        case 'disabled':
+        default:
+            return <CircleDashed className="h-4 w-4 text-muted-foreground flex-shrink-0" />;
+    }
+}
+
+/**
+ * Startup readiness banner.
+ *
+ * Polls `/api/system/readiness` and, while the backend is warming up (loading
+ * the search model, downloading/loading the local AI server, etc.), shows a
+ * non-blocking banner that explains in plain language what's happening and —
+ * for tracked downloads — roughly how long is left. It only appears when there
+ * is actual warm-up to report (so a fast, fully-cached launch shows nothing),
+ * and auto-dismisses shortly after everything is ready.
+ */
+export function StartupStatus() {
+    const [dismissed, setDismissed] = useState(
+        () => sessionStorage.getItem('startupStatusDismissed') === '1'
+    );
+    // Only surface the banner once we've actually observed warm-up, so a launch
+    // where everything is already cached never flashes a banner.
+    const [sawWarmup, setSawWarmup] = useState(false);
+
+    const { data } = useQuery<ReadinessResponse>({
+        queryKey: ['system-readiness'],
+        queryFn: async () => {
+            const res = await fetch('/api/system/readiness');
+            if (!res.ok) throw new Error(`readiness ${res.status}`);
+            return res.json();
+        },
+        enabled: !dismissed,
+        // Poll while warming up; stop once everything is ready.
+        refetchInterval: (query) => (query.state.data?.all_ready ? false : 1500),
+        retry: true,
+    });
+
+    useEffect(() => {
+        if (data && (!data.core_ready || !data.all_ready)) {
+            setSawWarmup(true);
+        }
+    }, [data]);
+
+    // Once ready, hold the "all set" confirmation briefly, then dismiss.
+    useEffect(() => {
+        if (data?.all_ready && sawWarmup && !dismissed) {
+            const t = setTimeout(() => setDismissed(true), 3000);
+            return () => clearTimeout(t);
+        }
+    }, [data?.all_ready, sawWarmup, dismissed]);
+
+    const dismiss = () => {
+        sessionStorage.setItem('startupStatusDismissed', '1');
+        setDismissed(true);
+    };
+
+    if (dismissed || !data) return null;
+    // Nothing to report (fully cached launch): stay invisible.
+    if (!sawWarmup && data.all_ready) return null;
+
+    const title = !data.core_ready
+        ? 'Starting ScreenSearch…'
+        : data.all_ready
+            ? 'ScreenSearch is ready'
+            : 'Getting AI features ready…';
+
+    return (
+        <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-[min(92vw,460px)]">
+            <div className="bg-card/95 backdrop-blur border border-border rounded-xl shadow-lg p-4 space-y-3">
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        {data.all_ready ? (
+                            <CheckCircle2 className="h-4 w-4 text-green-500" />
+                        ) : (
+                            <Loader2 className="h-4 w-4 text-primary animate-spin" />
+                        )}
+                        <span className="font-medium text-sm">{title}</span>
+                    </div>
+                    <button
+                        onClick={dismiss}
+                        className="text-muted-foreground hover:text-foreground"
+                        aria-label="Dismiss startup status"
+                    >
+                        <X className="h-4 w-4" />
+                    </button>
+                </div>
+
+                {!data.core_ready && (
+                    <p className="text-xs text-muted-foreground">
+                        You can start searching as soon as core services finish starting.
+                    </p>
+                )}
+
+                <ul className="space-y-2">
+                    {data.stages.map((stage) => {
+                        const pct =
+                            stage.state === 'downloading' && stage.progress != null
+                                ? Math.min(Math.max(stage.progress, 0), 100)
+                                : null;
+                        const eta = formatEta(stage.eta_seconds);
+                        return (
+                            <li key={stage.id} className="flex items-start gap-2.5">
+                                <span className="mt-0.5">
+                                    <StageIcon state={stage.state} />
+                                </span>
+                                <div className="min-w-0 flex-1">
+                                    <div className="flex items-center justify-between gap-2">
+                                        <span
+                                            className={`text-sm ${
+                                                stage.state === 'disabled'
+                                                    ? 'text-muted-foreground'
+                                                    : 'text-foreground'
+                                            }`}
+                                        >
+                                            {stage.label}
+                                        </span>
+                                        {pct != null && (
+                                            <span className="text-xs font-mono text-muted-foreground whitespace-nowrap">
+                                                {pct.toFixed(0)}%{eta ? ` · ${eta}` : ''}
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-xs text-muted-foreground leading-snug">
+                                        {stage.detail}
+                                    </p>
+                                    {pct != null && (
+                                        <div className="w-full bg-secondary rounded-full h-1.5 overflow-hidden mt-1.5">
+                                            <div
+                                                className="h-full bg-primary transition-all duration-300"
+                                                style={{ width: `${pct}%` }}
+                                            />
+                                        </div>
+                                    )}
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ul>
+            </div>
+        </div>
+    );
+}

--- a/screensearch-ui/src/components/search/SearchInvite.tsx
+++ b/screensearch-ui/src/components/search/SearchInvite.tsx
@@ -263,7 +263,7 @@ export function SearchInvite({ isOpen, onClose }: SearchInviteProps) {
                     <span>to close</span>
                   </span>
                 </div>
-                <span className="text-primary/70">ScreenSearch Intel</span>
+                <span className="text-primary/70">Insights</span>
               </div>
             </div>
           </motion.div>

--- a/screensearch-ui/src/pages/Dashboard.tsx
+++ b/screensearch-ui/src/pages/Dashboard.tsx
@@ -10,7 +10,7 @@ export function DashboardPage() {
       {/* Page Header */}
       <div className="space-y-2">
         <h1 className="font-serif text-[34px] lg:text-[42px] leading-[1.08] tracking-[-0.01em] text-ink">
-          ScreenSearch Intel
+          Insights
         </h1>
         <p className="text-ink-2 text-[16px] leading-[1.6]">
           Your AI-powered productivity insights at a glance.

--- a/screensearch-ui/src/pages/Intelligence.tsx
+++ b/screensearch-ui/src/pages/Intelligence.tsx
@@ -6,7 +6,7 @@ export function IntelligencePage() {
         <div className="max-w-6xl mx-auto space-y-8 animate-in fade-in duration-500">
             <div className="space-y-2">
                 <h1 className="font-serif text-[34px] lg:text-[42px] leading-[1.08] tracking-[-0.01em] text-ink">
-                    Intelligence
+                    Insights
                 </h1>
                 <p className="text-ink-2 text-[16px] leading-[1.6]">
                     Generate insights and summaries from your ScreenSearch data using AI.


### PR DESCRIPTION
Follow-up fixes on top of the unified gemma-4 vision server (#70). Reported symptom: enabling **Answer Generation** spammed `image input is not supported … you may need to provide the mmproj`, the local server didn't appear to use the GPU, "Process frames" was slow, and the Settings AI card hung on its loading skeleton.

## Vision / model selection
- **Default `vision_model` is now Gemma 4 E4B** (migration `011_gemma4_vision_default`). The previous text-only Ministral-3B default had no projector, so every image request failed.
- `resolve_vision_model` prefers a **higher-quality quant** (Q4 over Q2/Q3) within a tier; model discovery skips non-loadable GGUFs (`*mmproj*`, `mtp-*` helper heads, undersized files).
- **`GET /api/vision/models`** + a **Settings dropdown** to choose which dropped model the unified server loads.

## GPU visibility
- Capture llama-server stdout/stderr to **`bin/llama-server.log`** (was discarded), so Vulkan init / fallback is diagnosable.
- **Scale the GPU health-check timeout by model size** so a multi-GB model loading into VRAM isn't falsely bounced to CPU.
- Track GPU/CPU mode and expose it via **`GET /api/ai/server/status` (`acceleration`)**; show a badge in Settings.

## Stability / performance
- **SQLite `busy_timeout`** so the vision worker no longer hits `database is locked` under concurrent capture/OCR writes.
- **`engine_ready` probe uses `try_read`** so `GET /embeddings/status` no longer hangs during the first-run embedding-model download (the cause of the frozen Settings card); UI adds an 8s fetch timeout.
- **"Process frames" runs in the background** and returns immediately; chunks are embedded in size-bounded cross-frame batches; fastembed batch size 16 → 32.

## UI
- Rename the **"ScreenSearch Intel" / "Intelligence"** surfaces to **"Insights"**.
- New **`StartupStatus`** banner backed by **`GET /api/system/readiness`** that explains backend warm-up (core, semantic search, AI generation) with per-stage state, plain-language detail, and progress/ETA for downloads; only appears when there's actual warm-up and auto-hides when ready.

## Docs
Updated CHANGELOG, architecture, vision, api-reference, embedded-llm, CODE_NAVIGATION.

## Verification
- `cargo check --workspace` clean; `cargo clippy` (api/db/embeddings/llm) no new warnings; `rustfmt --check` on changed files OK.
- `cargo test -p screensearch-llm --lib` → 32 passed (incl. new quant-selection tests); `-p screensearch-db` 3 passed; `-p screensearch-embeddings` 8 passed.
- `npm run build` (tsc) clean.
- Runtime, clean single instance:
  - `GET /api/vision/models` → selected `gemma-4-E4B-it-qat-UD-Q4_K_XL` (Q4 chosen over Q2/12B; `mtp-*`/projectors excluded).
  - Vision frames complete on **GPU (Vulkan)** with no `image input is not supported`.
  - `GET /api/embeddings/status` → 200 in ~5 ms (was hanging).
  - `GET /api/system/readiness` → valid per-stage JSON; banner hidden on cached launch.

## Notes / follow-up
- Force-killing ScreenSearch on Windows orphans its `llama-server` child (no Job Object yet) — can pile up extra servers on the port. A Job Object so the child dies with the parent is a suggested follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)