### PR TITLE
feat(embeddings): embed vision description for non-OCR visual recall (Tier 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   each frame's text embedding (previously they were stored as metadata and never
   embedded), giving non-OCR visual content — charts, design canvases, icon-heavy UIs —
   a semantic recall path through the existing 768-dim EmbeddingGemma index. No new
-  models, dependencies, or schema changes. Because vision analysis is asynchronous and
-  may finish after a frame was first embedded on OCR alone, `complete_analysis_task`
-  now clears that frame's embeddings when it records a (non-empty) description, so the
-  background worker re-embeds it with the vision fields included. The combined
-  embedding text is now built by a single shared `build_frame_embedding_text` helper
-  used by both the background worker and the manual generate-embeddings handler.
-  Files: `screensearch-api/src/workers/embedding_worker.rs`,
+  models, dependencies, or schema changes. Frames are now embeddable when they have
+  OCR text **or** vision text, so a frame with no OCR at all (a pure chart/canvas) is
+  embedded once vision describes it. Because vision analysis is asynchronous and may
+  finish after a frame was first embedded on OCR alone, `complete_analysis_task` now
+  clears that frame's embeddings when it records vision text (a non-empty `description`
+  or `visible_text` labels), so the background worker re-embeds it with the vision
+  fields included. The combined embedding text is built by a single shared
+  `build_frame_embedding_text` helper used by both the background worker and the manual
+  generate-embeddings handler. Files: `screensearch-api/src/workers/embedding_worker.rs`,
   `screensearch-api/src/handlers/embeddings.rs`, `screensearch-db/src/queries.rs`.
 
 - **Complete frontend rebuild — "Command Deck" UI (greenfield).** The React UI was

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Visual recall, Tier 1: the vision description is now embedded.** The generative
+  vision worker's per-frame `description` + `visible_text` labels are now folded into
+  each frame's text embedding (previously they were stored as metadata and never
+  embedded), giving non-OCR visual content — charts, design canvases, icon-heavy UIs —
+  a semantic recall path through the existing 768-dim EmbeddingGemma index. No new
+  models, dependencies, or schema changes. Because vision analysis is asynchronous and
+  may finish after a frame was first embedded on OCR alone, `complete_analysis_task`
+  now clears that frame's embeddings when it records a (non-empty) description, so the
+  background worker re-embeds it with the vision fields included. The combined
+  embedding text is now built by a single shared `build_frame_embedding_text` helper
+  used by both the background worker and the manual generate-embeddings handler.
+  Files: `screensearch-api/src/workers/embedding_worker.rs`,
+  `screensearch-api/src/handlers/embeddings.rs`, `screensearch-db/src/queries.rs`.
+
 - **Complete frontend rebuild — "Command Deck" UI (greenfield).** The React UI was
   rebuilt from scratch with a new, deliberately non-generic visual identity:
   a warm-graphite + signal-orange instrument/telemetry aesthetic, Windows-native

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -87,7 +87,15 @@ The current embedding contract is fixed:
 
 The model (fastembed variant `EmbeddingGemma300MQ`) is downloaded and cached
 from Hugging Face on first use. Document chunks include OCR text plus frame
-timestamp, application, and window metadata.
+timestamp, application, and window metadata, and — when vision analysis has run —
+the generated `description` and `visible_text` labels, so non-OCR visual content
+(charts, canvases, icon-heavy UIs) gains a text recall path. Because vision
+analysis is asynchronous and may finish after a frame is first embedded (on OCR
+alone), `complete_analysis_task` clears that frame's embeddings when it records a
+description, and the background worker re-embeds it with the vision fields
+included. The shared `build_frame_embedding_text` helper
+(`screensearch-api/src/workers/embedding_worker.rs`) is used by both the
+background worker and the manual generate-embeddings handler so they never drift.
 
 Each stored embedding records provider, model, revision, dimension, and a
 SHA-256 content hash. ScreenSearch does not generate hash-based placeholder

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,13 +89,16 @@ The model (fastembed variant `EmbeddingGemma300MQ`) is downloaded and cached
 from Hugging Face on first use. Document chunks include OCR text plus frame
 timestamp, application, and window metadata, and — when vision analysis has run —
 the generated `description` and `visible_text` labels, so non-OCR visual content
-(charts, canvases, icon-heavy UIs) gains a text recall path. Because vision
-analysis is asynchronous and may finish after a frame is first embedded (on OCR
-alone), `complete_analysis_task` clears that frame's embeddings when it records a
-description, and the background worker re-embeds it with the vision fields
-included. The shared `build_frame_embedding_text` helper
-(`screensearch-api/src/workers/embedding_worker.rs`) is used by both the
-background worker and the manual generate-embeddings handler so they never drift.
+(charts, canvases, icon-heavy UIs) gains a text recall path. A frame is eligible
+for embedding when it has OCR text **or** vision-derived text, so a frame with no
+OCR at all (a pure chart/canvas) is still embedded once vision describes it.
+Because vision analysis is asynchronous and may finish after a frame is first
+embedded (on OCR alone), `complete_analysis_task` clears that frame's embeddings
+when it records vision text (a non-empty `description` or `visible_text` labels),
+and the background worker re-embeds it with the vision fields included. The shared
+`build_frame_embedding_text` helper (`screensearch-api/src/workers/embedding_worker.rs`)
+is used by both the background worker and the manual generate-embeddings handler
+so they never drift.
 
 Each stored embedding records provider, model, revision, dimension, and a
 SHA-256 content hash. ScreenSearch does not generate hash-based placeholder

--- a/screensearch-api/src/handlers/embeddings.rs
+++ b/screensearch-api/src/handlers/embeddings.rs
@@ -206,13 +206,8 @@ async fn run_embedding_job(state: &Arc<AppState>, batch_size: i64) -> i64 {
             .map(|o| o.text.as_str())
             .collect::<Vec<_>>()
             .join(" ");
-        let combined_text = format!(
-            "Timestamp: {}\nApplication: {}\nWindow: {}\nScreen text:\n{}",
-            frame.timestamp,
-            frame.active_process.as_deref().unwrap_or("Unknown"),
-            frame.active_window.as_deref().unwrap_or(""),
-            ocr_text
-        );
+        let combined_text =
+            crate::workers::embedding_worker::build_frame_embedding_text(frame, &ocr_text);
         let chunks = match engine.chunk_text(&combined_text, 512, 64).await {
             Ok(chunks) => chunks,
             Err(error) => {

--- a/screensearch-api/src/handlers/embeddings.rs
+++ b/screensearch-api/src/handlers/embeddings.rs
@@ -197,15 +197,23 @@ async fn run_embedding_job(state: &Arc<AppState>, batch_size: i64) -> i64 {
                 continue;
             }
         };
-        if ocr_texts.is_empty() {
-            continue;
-        }
-
         let ocr_text: String = ocr_texts
             .iter()
             .map(|o| o.text.as_str())
             .collect::<Vec<_>>()
             .join(" ");
+
+        // Embed when there's OCR text OR vision-derived text; skip frames with
+        // neither (nothing but metadata to embed).
+        if ocr_text.trim().is_empty()
+            && !crate::workers::embedding_worker::frame_has_vision_text(
+                frame.description.as_deref(),
+                frame.visible_text_json.as_deref(),
+            )
+        {
+            continue;
+        }
+
         let combined_text =
             crate::workers::embedding_worker::build_frame_embedding_text(frame, &ocr_text);
         let chunks = match engine.chunk_text(&combined_text, 512, 64).await {

--- a/screensearch-api/src/workers/embedding_worker.rs
+++ b/screensearch-api/src/workers/embedding_worker.rs
@@ -50,6 +50,21 @@ pub fn build_frame_embedding_text(frame: &FrameRecord, ocr_text: &str) -> String
     text
 }
 
+/// Whether a frame carries vision-derived text worth embedding: a non-empty
+/// `description` or non-empty `visible_text` labels. Mirrors the fields
+/// [`build_frame_embedding_text`] appends, and is used to decide whether a frame
+/// with no OCR text is still embeddable.
+pub fn frame_has_vision_text(description: Option<&str>, visible_text_json: Option<&str>) -> bool {
+    let has_description = description.map(|d| !d.trim().is_empty()).unwrap_or(false);
+    let has_labels = visible_text_json
+        .map(|v| {
+            let trimmed = v.trim();
+            !trimmed.is_empty() && trimmed != "[]"
+        })
+        .unwrap_or(false);
+    has_description || has_labels
+}
+
 /// Configuration for the background embedding worker
 #[derive(Debug, Clone)]
 pub struct EmbeddingWorkerConfig {
@@ -107,19 +122,25 @@ impl EmbeddingWorker {
         for frame in frames {
             // Get OCR text for the frame
             let ocr_texts = self.db.get_ocr_text_for_frame(frame.id).await?;
-
-            if ocr_texts.is_empty() {
-                // No OCR text, still mark as processed by inserting empty embedding
-                debug!("Frame {} has no OCR text", frame.id);
-                continue;
-            }
-
-            // Combine OCR text + vision fields and chunk it
             let ocr_text: String = ocr_texts
                 .iter()
                 .map(|o| o.text.as_str())
                 .collect::<Vec<_>>()
                 .join(" ");
+
+            // Embed when there's OCR text OR vision-derived text; a frame with
+            // neither has nothing to embed (would be metadata only), so skip it.
+            if ocr_text.trim().is_empty()
+                && !frame_has_vision_text(
+                    frame.description.as_deref(),
+                    frame.visible_text_json.as_deref(),
+                )
+            {
+                debug!("Frame {} has no embeddable text", frame.id);
+                continue;
+            }
+
+            // Combine OCR text + vision fields and chunk it
             let combined_text = build_frame_embedding_text(&frame, &ocr_text);
             let chunks = self.engine.chunk_text(&combined_text, 512, 64).await?;
 
@@ -294,5 +315,15 @@ mod tests {
         assert!(!text.contains("Visual summary"));
         // an empty JSON array flattens to an empty string -> no label line
         assert!(!text.contains("Visible labels"));
+    }
+
+    #[test]
+    fn vision_text_detection() {
+        assert!(!frame_has_vision_text(None, None));
+        assert!(!frame_has_vision_text(Some("   "), Some("[]")));
+        assert!(!frame_has_vision_text(Some(""), Some("")));
+        assert!(frame_has_vision_text(Some("a bar chart"), None));
+        assert!(frame_has_vision_text(None, Some(r#"["Submit","Cancel"]"#)));
+        assert!(frame_has_vision_text(Some("desc"), Some("[]")));
     }
 }

--- a/screensearch-api/src/workers/embedding_worker.rs
+++ b/screensearch-api/src/workers/embedding_worker.rs
@@ -2,11 +2,53 @@
 //!
 //! Processes frames without embeddings in the background.
 
-use screensearch_db::DatabaseManager;
+use screensearch_db::{DatabaseManager, FrameRecord};
 use screensearch_embeddings::EmbeddingEngine;
+use std::fmt::Write as _;
 use std::sync::Arc;
 use tokio::time::{interval, Duration};
 use tracing::{debug, error, info, warn};
+
+/// Build the text embedded for a frame: OCR text plus the vision worker's
+/// `description` and `visible_text` labels when present.
+///
+/// Shared by the background worker and the manual generate-embeddings handler so
+/// the two never drift. Including the vision fields gives non-OCR visual content
+/// (charts, canvases, icon-heavy UIs) a recall path it otherwise lacks; the
+/// vision fields are skipped when absent/empty so OCR-only frames are unchanged.
+pub fn build_frame_embedding_text(frame: &FrameRecord, ocr_text: &str) -> String {
+    let mut text = format!(
+        "Timestamp: {}\nApplication: {}\nWindow: {}\nScreen text:\n{}",
+        frame.timestamp,
+        frame.active_process.as_deref().unwrap_or("Unknown"),
+        frame.active_window.as_deref().unwrap_or(""),
+        ocr_text
+    );
+
+    if let Some(desc) = frame.description.as_deref() {
+        let desc = desc.trim();
+        if !desc.is_empty() {
+            let _ = write!(text, "\nVisual summary:\n{desc}");
+        }
+    }
+
+    if let Some(raw) = frame.visible_text_json.as_deref() {
+        let raw = raw.trim();
+        if !raw.is_empty() {
+            // `visible_text_json` is a JSON array of strings; flatten to a
+            // readable line, falling back to the raw value if it isn't that shape.
+            let labels = serde_json::from_str::<Vec<String>>(raw)
+                .map(|v| v.join(", "))
+                .unwrap_or_else(|_| raw.to_string());
+            let labels = labels.trim();
+            if !labels.is_empty() {
+                let _ = write!(text, "\nVisible labels: {labels}");
+            }
+        }
+    }
+
+    text
+}
 
 /// Configuration for the background embedding worker
 #[derive(Debug, Clone)]
@@ -72,19 +114,13 @@ impl EmbeddingWorker {
                 continue;
             }
 
-            // Combine OCR text and chunk it
+            // Combine OCR text + vision fields and chunk it
             let ocr_text: String = ocr_texts
                 .iter()
                 .map(|o| o.text.as_str())
                 .collect::<Vec<_>>()
                 .join(" ");
-            let combined_text = format!(
-                "Timestamp: {}\nApplication: {}\nWindow: {}\nScreen text:\n{}",
-                frame.timestamp,
-                frame.active_process.as_deref().unwrap_or("Unknown"),
-                frame.active_window.as_deref().unwrap_or(""),
-                ocr_text
-            );
+            let combined_text = build_frame_embedding_text(&frame, &ocr_text);
             let chunks = self.engine.chunk_text(&combined_text, 512, 64).await?;
 
             let chunk_refs: Vec<&str> = chunks.iter().map(String::as_str).collect();
@@ -189,4 +225,74 @@ pub fn spawn_embedding_worker(
         let worker = EmbeddingWorker::new(db, engine, config);
         worker.run().await;
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn make_frame(description: Option<&str>, visible_text_json: Option<&str>) -> FrameRecord {
+        FrameRecord {
+            id: 1,
+            chunk_id: None,
+            timestamp: Utc::now(),
+            monitor_index: 0,
+            device_name: "monitor-0".to_string(),
+            file_path: "captures/frame.jpg".to_string(),
+            active_window: Some("Editor".to_string()),
+            active_process: Some("code.exe".to_string()),
+            browser_url: None,
+            width: 1280,
+            height: 720,
+            offset_index: 0,
+            focused: Some(true),
+            created_at: Utc::now(),
+            analysis_status: Some("completed".to_string()),
+            description: description.map(str::to_string),
+            visible_text_json: visible_text_json.map(str::to_string),
+            activity_type: Some("coding".to_string()),
+            app_hint: Some("VS Code".to_string()),
+            confidence: Some(0.9),
+            analysis_time_ms: Some(100),
+            analysis_error: None,
+        }
+    }
+
+    #[test]
+    fn ocr_only_when_no_vision_fields() {
+        let frame = make_frame(None, None);
+        let text = build_frame_embedding_text(&frame, "hello world");
+        assert!(text.contains("Screen text:\nhello world"));
+        assert!(!text.contains("Visual summary"));
+        assert!(!text.contains("Visible labels"));
+    }
+
+    #[test]
+    fn includes_description_and_flattened_visible_labels() {
+        let frame = make_frame(
+            Some("a bar chart of Q3 revenue"),
+            Some(r#"["Q3","Revenue","Sales"]"#),
+        );
+        let text = build_frame_embedding_text(&frame, "ocr text");
+        assert!(text.contains("Screen text:\nocr text"));
+        assert!(text.contains("Visual summary:\na bar chart of Q3 revenue"));
+        assert!(text.contains("Visible labels: Q3, Revenue, Sales"));
+    }
+
+    #[test]
+    fn falls_back_on_non_json_visible_text() {
+        let frame = make_frame(None, Some("just a raw string"));
+        let text = build_frame_embedding_text(&frame, "ocr");
+        assert!(text.contains("Visible labels: just a raw string"));
+    }
+
+    #[test]
+    fn skips_empty_vision_fields() {
+        let frame = make_frame(Some("   "), Some("[]"));
+        let text = build_frame_embedding_text(&frame, "ocr");
+        assert!(!text.contains("Visual summary"));
+        // an empty JSON array flattens to an empty string -> no label line
+        assert!(!text.contains("Visible labels"));
+    }
 }

--- a/screensearch-db/src/queries.rs
+++ b/screensearch-db/src/queries.rs
@@ -1275,6 +1275,13 @@ impl DatabaseManager {
     ) -> Result<()> {
         let mut tx = self.pool().begin().await?;
 
+        // Whether vision produced a non-empty description worth re-embedding for.
+        let has_description = analysis
+            .description
+            .as_deref()
+            .map(|d| !d.trim().is_empty())
+            .unwrap_or(false);
+
         // Update frame with analysis results
         sqlx::query(
             r#"
@@ -1305,6 +1312,19 @@ impl DatabaseManager {
             .bind(queue_id)
             .execute(&mut *tx)
             .await?;
+
+        // Vision analysis adds a semantic `description` + `visible_text` that the
+        // embedding text now includes. A frame embedded earlier (OCR only, before
+        // analysis finished) must be re-embedded to pick these up: deleting its
+        // embeddings here makes the background embedding worker re-select and
+        // re-embed it. The `embeddings_vector_delete` trigger (migration 009)
+        // cascades the deletion into the `embedding_vectors` KNN index.
+        if has_description {
+            sqlx::query("DELETE FROM embeddings WHERE frame_id = ?")
+                .bind(frame_id)
+                .execute(&mut *tx)
+                .await?;
+        }
 
         tx.commit().await?;
         Ok(())

--- a/screensearch-db/src/queries.rs
+++ b/screensearch-db/src/queries.rs
@@ -1275,12 +1275,22 @@ impl DatabaseManager {
     ) -> Result<()> {
         let mut tx = self.pool().begin().await?;
 
-        // Whether vision produced a non-empty description worth re-embedding for.
-        let has_description = analysis
+        // Whether vision produced text worth re-embedding for. The embedding text
+        // (build_frame_embedding_text) folds in BOTH the description and the
+        // visible_text labels, so either being present should trigger a re-embed.
+        let has_vision_text = analysis
             .description
             .as_deref()
             .map(|d| !d.trim().is_empty())
-            .unwrap_or(false);
+            .unwrap_or(false)
+            || analysis
+                .visible_text_json
+                .as_deref()
+                .map(|v| {
+                    let trimmed = v.trim();
+                    !trimmed.is_empty() && trimmed != "[]"
+                })
+                .unwrap_or(false);
 
         // Update frame with analysis results
         sqlx::query(
@@ -1319,7 +1329,7 @@ impl DatabaseManager {
         // embeddings here makes the background embedding worker re-select and
         // re-embed it. The `embeddings_vector_delete` trigger (migration 009)
         // cascades the deletion into the `embedding_vectors` KNN index.
-        if has_description {
+        if has_vision_text {
             sqlx::query("DELETE FROM embeddings WHERE frame_id = ?")
                 .bind(frame_id)
                 .execute(&mut *tx)
@@ -1392,7 +1402,12 @@ impl DatabaseManager {
         Ok(())
     }
 
-    /// Get OCR frames that don't have embeddings yet (for background processing).
+    /// Get frames that don't have embeddings yet (for background processing).
+    ///
+    /// A frame is eligible when it has embeddable text: either OCR text, or
+    /// vision-derived text (a non-empty `description` or `visible_text_json`
+    /// labels). The latter lets frames with little/no on-screen text — charts,
+    /// canvases, icon-heavy UIs — be embedded once vision analysis has run.
     pub async fn get_frames_without_embeddings(&self, limit: i64) -> Result<Vec<FrameRecord>> {
         let frames = sqlx::query_as::<_, FrameRecord>(
             r#"
@@ -1404,7 +1419,13 @@ impl DatabaseManager {
             FROM frames f
             LEFT JOIN embeddings e ON f.id = e.frame_id
             WHERE e.id IS NULL
-              AND EXISTS (SELECT 1 FROM ocr_text o WHERE o.frame_id = f.id)
+              AND (
+                  EXISTS (SELECT 1 FROM ocr_text o WHERE o.frame_id = f.id)
+                  OR (f.description IS NOT NULL AND TRIM(f.description) <> '')
+                  OR (f.visible_text_json IS NOT NULL
+                      AND TRIM(f.visible_text_json) <> ''
+                      AND TRIM(f.visible_text_json) <> '[]')
+              )
             ORDER BY f.id ASC
             LIMIT ?
             "#,

--- a/screensearch-db/tests/integration_tests.rs
+++ b/screensearch-db/tests/integration_tests.rs
@@ -866,6 +866,109 @@ async fn test_vision_completion_clears_embeddings_for_reembedding() {
     db.close().await;
 }
 
+/// A vision completion with only `visible_text` labels (no description) must
+/// still clear embeddings, since those labels are part of the embedding text.
+#[tokio::test]
+async fn test_vision_completion_with_labels_only_clears_embeddings() {
+    use screensearch_db::models::FrameAnalysisUpdate;
+
+    let (db, _path) = create_test_db().await;
+
+    let frame_id = db
+        .insert_frame(create_test_frame(Utc::now(), "app", "Toolbar"))
+        .await
+        .unwrap();
+    db.insert_ocr_text(create_test_ocr(frame_id, "screen text"))
+        .await
+        .unwrap();
+    db.insert_embedding(NewEmbedding {
+        frame_id,
+        chunk_text: "screen text".to_string(),
+        chunk_index: 0,
+        embedding: vec![0.1; 768],
+        provider: "fastembed".to_string(),
+        model: "EmbeddingGemma-300M".to_string(),
+        model_version: "1".to_string(),
+        content_hash: "hash".to_string(),
+    })
+    .await
+    .unwrap();
+
+    db.enqueue_frame_for_analysis(frame_id, 0).await.unwrap();
+    let task = db.claim_analysis_task("w").await.unwrap().unwrap();
+    db.complete_analysis_task(
+        task.id,
+        frame_id,
+        FrameAnalysisUpdate {
+            description: None,
+            visible_text_json: Some(r#"["Submit","Cancel","Settings"]"#.to_string()),
+            activity_type: Some("productivity".to_string()),
+            app_hint: None,
+            confidence: Some(0.7),
+            analysis_time_ms: Some(8),
+        },
+    )
+    .await
+    .unwrap();
+
+    let pending = db.get_frames_without_embeddings(10).await.unwrap();
+    assert!(
+        pending.iter().any(|f| f.id == frame_id),
+        "labels-only vision completion should re-queue the frame for embedding"
+    );
+
+    db.close().await;
+}
+
+/// A frame with NO OCR text but a vision description must become embeddable
+/// (the "pure chart / canvas" case the feature targets).
+#[tokio::test]
+async fn test_frame_without_ocr_but_with_description_is_embeddable() {
+    use screensearch_db::models::FrameAnalysisUpdate;
+
+    let (db, _path) = create_test_db().await;
+
+    let frame_id = db
+        .insert_frame(create_test_frame(Utc::now(), "figma", "Canvas"))
+        .await
+        .unwrap();
+    // Deliberately no OCR text inserted.
+
+    // Before vision: nothing embeddable -> not pending.
+    let pending = db.get_frames_without_embeddings(10).await.unwrap();
+    assert!(
+        !pending.iter().any(|f| f.id == frame_id),
+        "a frame with neither OCR nor vision text must not be embeddable"
+    );
+
+    // Vision adds a description.
+    db.enqueue_frame_for_analysis(frame_id, 0).await.unwrap();
+    let task = db.claim_analysis_task("w").await.unwrap().unwrap();
+    db.complete_analysis_task(
+        task.id,
+        frame_id,
+        FrameAnalysisUpdate {
+            description: Some("a dashboard mockup with a blue bar chart".to_string()),
+            visible_text_json: Some("[]".to_string()),
+            activity_type: Some("design".to_string()),
+            app_hint: None,
+            confidence: Some(0.8),
+            analysis_time_ms: Some(12),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Now embeddable purely on the vision description.
+    let pending = db.get_frames_without_embeddings(10).await.unwrap();
+    assert!(
+        pending.iter().any(|f| f.id == frame_id),
+        "a frame with a vision description should be embeddable even without OCR"
+    );
+
+    db.close().await;
+}
+
 /// A vision completion with no description must NOT wipe existing embeddings.
 #[tokio::test]
 async fn test_vision_completion_without_description_keeps_embeddings() {

--- a/screensearch-db/tests/integration_tests.rs
+++ b/screensearch-db/tests/integration_tests.rs
@@ -798,3 +798,124 @@ async fn test_vision_status_counts_by_analysis_status() {
 
     db.close().await;
 }
+
+/// When vision analysis completes with a description, a frame that was already
+/// embedded (OCR only, before analysis finished) must have its embeddings cleared
+/// so the background worker re-embeds it with the new description included.
+#[tokio::test]
+async fn test_vision_completion_clears_embeddings_for_reembedding() {
+    use screensearch_db::models::FrameAnalysisUpdate;
+
+    let (db, _path) = create_test_db().await;
+
+    let frame_id = db
+        .insert_frame(create_test_frame(Utc::now(), "design", "Canvas"))
+        .await
+        .unwrap();
+    // OCR text makes the frame eligible for embedding.
+    db.insert_ocr_text(create_test_ocr(frame_id, "some screen text"))
+        .await
+        .unwrap();
+
+    // Embed it OCR-only, as the worker would before vision completes.
+    db.insert_embedding(NewEmbedding {
+        frame_id,
+        chunk_text: "some screen text".to_string(),
+        chunk_index: 0,
+        embedding: vec![0.1; 768],
+        provider: "fastembed".to_string(),
+        model: "EmbeddingGemma-300M".to_string(),
+        model_version: "1".to_string(),
+        content_hash: "hash".to_string(),
+    })
+    .await
+    .unwrap();
+
+    // Embedded -> no longer pending.
+    let pending = db.get_frames_without_embeddings(10).await.unwrap();
+    assert!(
+        !pending.iter().any(|f| f.id == frame_id),
+        "frame should not be pending once embedded"
+    );
+
+    // Vision completes with a non-empty description.
+    db.enqueue_frame_for_analysis(frame_id, 0).await.unwrap();
+    let task = db.claim_analysis_task("w").await.unwrap().unwrap();
+    db.complete_analysis_task(
+        task.id,
+        frame_id,
+        FrameAnalysisUpdate {
+            description: Some("a bar chart of quarterly revenue".to_string()),
+            visible_text_json: Some("[]".to_string()),
+            activity_type: Some("design".to_string()),
+            app_hint: None,
+            confidence: Some(0.8),
+            analysis_time_ms: Some(10),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Embeddings cleared -> frame is re-queued for embedding.
+    let pending = db.get_frames_without_embeddings(10).await.unwrap();
+    assert!(
+        pending.iter().any(|f| f.id == frame_id),
+        "frame should be re-queued for embedding after vision adds a description"
+    );
+
+    db.close().await;
+}
+
+/// A vision completion with no description must NOT wipe existing embeddings.
+#[tokio::test]
+async fn test_vision_completion_without_description_keeps_embeddings() {
+    use screensearch_db::models::FrameAnalysisUpdate;
+
+    let (db, _path) = create_test_db().await;
+
+    let frame_id = db
+        .insert_frame(create_test_frame(Utc::now(), "code", "Doc"))
+        .await
+        .unwrap();
+    db.insert_ocr_text(create_test_ocr(frame_id, "screen text"))
+        .await
+        .unwrap();
+    db.insert_embedding(NewEmbedding {
+        frame_id,
+        chunk_text: "screen text".to_string(),
+        chunk_index: 0,
+        embedding: vec![0.1; 768],
+        provider: "fastembed".to_string(),
+        model: "EmbeddingGemma-300M".to_string(),
+        model_version: "1".to_string(),
+        content_hash: "hash".to_string(),
+    })
+    .await
+    .unwrap();
+
+    db.enqueue_frame_for_analysis(frame_id, 0).await.unwrap();
+    let task = db.claim_analysis_task("w").await.unwrap().unwrap();
+    db.complete_analysis_task(
+        task.id,
+        frame_id,
+        FrameAnalysisUpdate {
+            description: None,
+            visible_text_json: None,
+            activity_type: None,
+            app_hint: None,
+            confidence: None,
+            analysis_time_ms: Some(5),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Still embedded -> not pending.
+    let pending = db.get_frames_without_embeddings(10).await.unwrap();
+    assert!(
+        !pending.iter().any(|f| f.id == frame_id),
+        "embeddings must be preserved when vision adds no description"
+    );
+
+    db.close().await;
+}


### PR DESCRIPTION
## Summary

**Tier 1 of the visual-recall work** (POC: #74). Content with little/no on-screen text — charts, design canvases, icon-heavy UIs — currently has **no recall path**: search only reaches OCR text. This PR folds the vision worker's already-produced `description` + `visible_text` labels into each frame's text embedding, so that content becomes semantically searchable through the **existing 768-dim EmbeddingGemma index**.

**No new models, dependencies, or schema changes.** (Tier 2 — the in-process nomic image-embedding index — is a separate follow-up PR.)

## Changes
- **Shared `build_frame_embedding_text` helper** (`embedding_worker.rs`) used by both the background worker and the manual generate-embeddings handler — the two previously duplicated the `combined_text` builder and could drift. The helper appends `description` + flattened `visible_text` labels when present (skips empty/absent fields; falls back to the raw value if `visible_text_json` isn't a JSON array).
- **Re-embed on vision completion** (`complete_analysis_task`): vision analysis is asynchronous and may finish *after* a frame was first embedded on OCR alone. When it records a non-empty description, the frame's embeddings are cleared (the migration-009 trigger cascades into the `embedding_vectors` KNN index), so the background worker re-embeds it with the vision fields included. A completion with no description leaves embeddings untouched.

## Tests (all green, run natively on Windows)
- 4 unit tests for `build_frame_embedding_text` (OCR-only, description+labels, non-JSON fallback, empty-field skipping).
- 2 integration tests for the re-embed behavior (clears on description; preserves when none).
- Full `screensearch-db` suite: 3 lib + 21 integration + 1 doc-test pass. `screensearch-api` lib tests pass. clippy + rustfmt clean on touched files.

```
running 4 tests
test workers::embedding_worker::tests::ocr_only_when_no_vision_fields ... ok
test workers::embedding_worker::tests::skips_empty_vision_fields ... ok
test workers::embedding_worker::tests::falls_back_on_non_json_visible_text ... ok
test workers::embedding_worker::tests::includes_description_and_flattened_visible_labels ... ok

test test_vision_completion_clears_embeddings_for_reembedding ... ok
test test_vision_completion_without_description_keeps_embeddings ... ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)