### PR TITLE
feat(embeddings): in-process image-embedding index for visual recall (Tier 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `docs/qwen3vl-embedding-poc.md`.
 
 ### Added
+- **Visual recall, Tier 2: optional in-process image-embedding index.** Screenshots
+  are now embedded directly from pixels with `nomic-embed-vision-v1.5` (768-dim) into a
+  separate sqlite-vec index, and `hybrid` search fuses image hits in via Reciprocal
+  Rank Fusion (queries encoded with the aligned `nomic-embed-text-v1.5`). This catches
+  non-OCR visual content the vision description misses — charts, dense canvases,
+  icon-only screens. Runs fully in-process (fastembed/ONNX, CPU); no Python, llama.cpp,
+  or GPU. **Off by default** (`embeddings.image_enabled`, also toggleable at runtime via
+  `POST /api/embeddings/image/enable`); the nomic models download on first use and the
+  feature enables fastembed's `image-models` codecs (longer build). New: migration 013
+  (`image_embeddings` + `image_embedding_vectors` + contract metadata),
+  `ImageEmbeddingEngine`, `image_embedding_worker` (always spawned, lazy-loads only when
+  enabled), `hybrid_search` image fusion, and `GET/POST /api/embeddings/image/{status,
+  generate,enable}`. Proven 3/3: text queries retrieve the matching screenshot
+  (including a textless bar chart) via the shipping engine. Files:
+  `screensearch-embeddings/src/image_engine.rs`, `screensearch-db/src/{migrations,queries,vector_search}.rs`,
+  `screensearch-api/src/{state,server,routes}.rs`,
+  `screensearch-api/src/workers/image_embedding_worker.rs`,
+  `screensearch-api/src/handlers/{embeddings,search}.rs`, `src/main.rs`.
+
 - **Visual recall, Tier 1: the vision description is now embedded.** The generative
   vision worker's per-frame `description` + `visible_text` labels are now folded into
   each frame's text embedding (previously they were stored as metadata and never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,6 +381,11 @@ max_width = 1280                # Resize frames to max width (maintains aspect r
 [embeddings]
 enabled = false                 # Enable semantic search with embeddings
 batch_size = 50                 # Frames to process per batch
+image_enabled = false           # Optional image-embedding index (visual recall):
+                                # embed screenshots with nomic-embed-vision-v1.5
+                                # (768-dim), fused into hybrid search. Off by
+                                # default; downloads nomic models on first use.
+                                # Runtime toggle: POST /api/embeddings/image/enable
 # Model identity (EmbeddingGemma-300M, 768-dim, fastembed), chunking, and hybrid
 # retrieval (Reciprocal Rank Fusion) are fixed by the in-process embedding engine
 # and are not configurable here. Optional bge-reranker-v2-m3 reranking is off by

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +146,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +179,15 @@ name = "as-raw-xcb-connection"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "async-trait"
@@ -199,6 +243,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
 
 [[package]]
 name = "axum"
@@ -313,6 +400,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +436,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c0e531d93d39c34eef561e929e8a7f86d77a5af08aac4f6d6e39976c51858e9"
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +458,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -1176,6 +1284,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1242,6 +1370,7 @@ checksum = "545e4fb17fc48768ff36c2a3854aa5b0b809d0ed595ab5530fa8ac94f31bd0ea"
 dependencies = [
  "anyhow",
  "hf-hub",
+ "image 0.25.10",
  "ndarray",
  "ort",
  "safetensors",
@@ -1255,6 +1384,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -1609,6 +1744,16 @@ name = "gif"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
 dependencies = [
  "color_quant",
  "weezl",
@@ -2253,12 +2398,46 @@ dependencies = [
  "byteorder",
  "color_quant",
  "exr",
- "gif",
+ "gif 0.13.3",
  "jpeg-decoder",
  "num-traits",
- "png",
+ "png 0.17.16",
  "qoi",
- "tiff",
+ "tiff 0.9.1",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif 0.14.2",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png 0.18.1",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff 0.11.3",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -2269,7 +2448,7 @@ checksum = "2f95582cde541e3ec8a855c2b395f340acd9984b26162c811e3e8d1defc5fec3"
 dependencies = [
  "approx",
  "conv",
- "image",
+ "image 0.24.9",
  "itertools 0.10.5",
  "nalgebra",
  "num",
@@ -2278,6 +2457,12 @@ dependencies = [
  "rayon",
  "rusttype",
 ]
+
+[[package]]
+name = "imgref"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89194689a993ab15268672e99e7b0e19da2da3268ac682e8f02d29d4d1434cd7"
 
 [[package]]
 name = "indexmap"
@@ -2324,6 +2509,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2551,6 +2747,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9fd2f41a1cba099f79a0b6b6c35656cf7c03351a7bae8ff0f28f25270f929d2"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2615,7 +2821,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "896d0e594158b7f5188034836a6c4886492078352c39760786e54f1b796caaea"
 dependencies = [
- "image",
+ "image 0.24.9",
  "log",
  "memmap2 0.7.1",
  "nix 0.26.4",
@@ -2684,6 +2890,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "macro_rules_attribute"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,6 +2937,16 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
 ]
 
 [[package]]
@@ -2842,6 +3067,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "muda"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2857,7 +3092,7 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png",
+ "png 0.17.16",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
@@ -2940,6 +3175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
 name = "nix"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2965,6 +3206,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2973,6 +3223,21 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3037,6 +3302,17 @@ name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-integer"
@@ -3566,6 +3842,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3708,6 +3990,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3832,6 +4127,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
 name = "qoi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3839,6 +4159,12 @@ checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -3995,6 +4321,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.14.0",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
 ]
 
 [[package]]
@@ -4202,6 +4578,12 @@ dependencies = [
  "wasm-streams",
  "web-sys",
 ]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
 
 [[package]]
 name = "ring"
@@ -4433,7 +4815,7 @@ dependencies = [
  "crossbeam",
  "dirs 5.0.1",
  "futures",
- "image",
+ "image 0.24.9",
  "reqwest 0.11.27",
  "screensearch-api",
  "screensearch-automation",
@@ -4459,7 +4841,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
- "image",
+ "image 0.24.9",
  "regex",
  "reqwest 0.11.27",
  "rust-embed",
@@ -4503,7 +4885,7 @@ dependencies = [
  "chrono",
  "crossbeam",
  "futures",
- "image",
+ "image 0.24.9",
  "imageproc",
  "rusttype",
  "screenshots",
@@ -4556,7 +4938,7 @@ dependencies = [
  "base64 0.21.7",
  "dirs 5.0.1",
  "futures-util",
- "image",
+ "image 0.24.9",
  "indicatif 0.17.11",
  "nix 0.28.0",
  "reqwest 0.11.27",
@@ -4577,7 +4959,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.21.7",
- "image",
+ "image 0.24.9",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
@@ -4596,7 +4978,7 @@ dependencies = [
  "dbus",
  "display-info",
  "fxhash",
- "image",
+ "image 0.24.9",
  "libwayshot",
  "percent-encoding",
  "widestring",
@@ -4808,6 +5190,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4919,7 +5310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
 dependencies = [
  "base64 0.13.1",
- "nom",
+ "nom 7.1.3",
  "serde",
  "unicode-segmentation",
 ]
@@ -5345,6 +5736,20 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
 ]
 
 [[package]]
@@ -5812,7 +6217,7 @@ dependencies = [
  "objc2-core-graphics",
  "objc2-foundation 0.3.2",
  "once_cell",
- "png",
+ "png 0.17.16",
  "thiserror 2.0.18",
  "windows-sys 0.60.2",
 ]
@@ -6001,6 +6406,17 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"
@@ -7203,6 +7619,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7361,10 +7783,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
 ]

--- a/config.toml
+++ b/config.toml
@@ -183,6 +183,14 @@ enabled = false
 # Batch size for background embedding generation
 batch_size = 50
 
+# Enable the optional in-process image-embedding index for visual recall:
+# screenshots are embedded with nomic-embed-vision-v1.5 (768-dim) and fused with
+# the text results at search time, so non-OCR visual content (charts, design
+# canvases, icon-heavy UIs) becomes searchable. Off by default — it downloads the
+# nomic vision/text models on first use and adds per-frame image-embedding CPU.
+# Can also be toggled at runtime via POST /api/embeddings/image/enable.
+image_enabled = false
+
 [llm]
 # Optional local answer-generation model (RAG summaries / Q&A) served by the
 # bundled llama.cpp server. Drop a GGUF file into `.models/` (or the app models

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -170,6 +170,36 @@ Processes OCR frames without current embeddings:
 
 The background worker also processes batches while embeddings are enabled.
 
+### Image embeddings (visual recall)
+
+An optional, in-process image-embedding index (nomic-embed-vision-v1.5, 768-dim)
+lets text queries retrieve frames by their pixels — including non-OCR visual
+content (charts, design canvases, icon-heavy UIs). Image hits are fused into
+`hybrid` search results via Reciprocal Rank Fusion. Off by default; the models
+download on first use and add per-frame image-embedding CPU.
+
+#### `GET /embeddings/image/status`
+
+Same shape as `GET /embeddings/status` (enabled, model, provider, dimension,
+coverage, `engine_ready`, …) but for the image index. `total_frames` counts all
+stored frames (no OCR requirement).
+
+#### `POST /embeddings/image/enable`
+
+Enable/disable the image index at runtime (JSON boolean body). The background
+image worker is always running and starts/stops processing accordingly.
+
+```bash
+curl -X POST "http://127.0.0.1:3131/api/embeddings/image/enable" \
+  -H "Content-Type: application/json" \
+  -d "true"
+```
+
+#### `POST /embeddings/image/generate`
+
+Backfill image embeddings for frames that lack one (same `{"batch_size": N}`
+body). Returns immediately; work runs in the background.
+
 ### `POST /generate`
 
 Generates a grounded answer:

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -188,6 +188,9 @@ stored frames (no OCR requirement).
 
 Enable/disable the image index at runtime (JSON boolean body). The background
 image worker is always running and starts/stops processing accordingly.
+Disabling stops further indexing and search fusion but does not unload the
+already-loaded nomic models from memory until the process restarts (the same
+behaviour as the text embedding engine).
 
 ```bash
 curl -X POST "http://127.0.0.1:3131/api/embeddings/image/enable" \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -130,17 +130,43 @@ distance_metric=cosine`, and metadata records `embeddings_model =
 "EmbeddingGemma-300M"`, `embeddings_provider = "fastembed"`, and
 `embeddings_dimension = "768"`.
 
+## Image Embeddings (visual recall)
+
+An optional, in-process image-embedding index gives non-OCR visual content
+(charts, design canvases, icon-heavy UIs) a recall path. Screenshots are embedded
+with `nomic-embed-vision-v1.5` and image-search queries with the aligned
+`nomic-embed-text-v1.5` — both 768-dim, run via the same fastembed/ONNX stack as
+the text embedder (`ImageEmbeddingEngine`). It is **off by default**
+(`embeddings.image_enabled`, also toggleable at runtime via
+`POST /api/embeddings/image/enable`); the models download on first use.
+
+Image vectors live in a **separate** `image_embeddings` table and
+`image_embedding_vectors` sqlite-vec index (migration 013), not the text
+`embedding_vectors` table: nomic-vision and EmbeddingGemma occupy different latent
+spaces, so a single KNN across both would be meaningless. The image index is one
+whole-frame vector per frame (no chunking), has its own model-contract metadata
+and invalidation (`ensure_image_embedding_model`), and is filled by a background
+worker (`image_embedding_worker`) that is always spawned but only loads models and
+processes frames while `image_embeddings_enabled` is set. The image-embedding text
+query path uses the nomic-text encoder, never EmbeddingGemma.
+
 ## Retrieval Pipeline
 
 ScreenSearch supports three search modes:
 
 - `fts`: SQLite FTS5 lexical retrieval;
 - `semantic`: sqlite-vec cosine KNN;
-- `hybrid`: FTS5 plus sqlite-vec.
+- `hybrid`: FTS5 plus sqlite-vec (and, when the image index is enabled and warm,
+  image-embedding hits).
 
 Hybrid retrieval uses Reciprocal Rank Fusion with `k = 60`. Rank fusion avoids
 mixing FTS and vector scores that have unrelated scales. The
-`hybrid_search_alpha` setting remains only for configuration compatibility.
+`hybrid_search_alpha` setting remains only for configuration compatibility. When
+image embeddings are enabled, `hybrid_search` queries the image index with the
+nomic-text query vector and folds those hits in as a third RRF list (cross-modal
+cosines are small in magnitude, so rank fusion — not a shared score threshold — is
+what makes them comparable). Image fusion is skipped on the search path unless the
+image engine is already loaded, so a first-run model download never blocks a query.
 
 sqlite-vec applies its KNN limit before timestamps from the joined frame table
 can be filtered. Time-constrained search expands the candidate set from the

--- a/screensearch-api/src/handlers/embeddings.rs
+++ b/screensearch-api/src/handlers/embeddings.rs
@@ -459,8 +459,19 @@ async fn run_image_embedding_job(state: &Arc<AppState>, batch_size: i64) -> i64 
 
     let mut total: i64 = 0;
     loop {
+        // Stop when no eligible frames remain. We gate on remaining frames (not on
+        // the embedded count) so a batch that only contains un-embeddable frames
+        // doesn't end the drain prematurely. The worker advances its cursor on
+        // every frame (success/failure/empty), so this always terminates.
+        match state.db.get_frames_without_image_embeddings(1).await {
+            Ok(pending) if pending.is_empty() => break,
+            Ok(_) => {}
+            Err(error) => {
+                warn!("Failed to check image-embedding backlog: {}", error);
+                break;
+            }
+        }
         match worker.process_batch().await {
-            Ok(0) => break,
             Ok(count) => total += count as i64,
             Err(error) => {
                 warn!("Image embedding batch failed: {}", error);

--- a/screensearch-api/src/handlers/embeddings.rs
+++ b/screensearch-api/src/handlers/embeddings.rs
@@ -354,3 +354,137 @@ pub async fn toggle_embeddings(
     // Return updated status
     get_embedding_status(State(state)).await
 }
+
+// ============================================================
+// Image embeddings (visual recall) — mirror the text endpoints
+// ============================================================
+
+/// Guards against overlapping on-demand image-embedding backfills.
+static IMAGE_EMBEDDING_JOB_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// GET /embeddings/image/status — coverage + readiness of the image index.
+pub async fn get_image_embedding_status(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<EmbeddingStatusResponse>> {
+    let engine_ready = state.image_embedding_engine_initialized().await;
+    let status = state.db.get_image_embedding_status().await?;
+
+    Ok(Json(EmbeddingStatusResponse {
+        enabled: status.enabled,
+        model: status.model,
+        provider: status.provider,
+        model_version: status.model_version,
+        dimension: status.dimension,
+        reindex_required: status.reindex_required,
+        engine_ready,
+        error: None,
+        total_frames: status.total_frames,
+        frames_with_embeddings: status.frames_with_embeddings,
+        coverage_percent: status.coverage_percent,
+        last_processed_frame_id: status.last_processed_frame_id,
+    }))
+}
+
+/// POST /embeddings/image/generate — backfill image embeddings for frames that
+/// lack one. Returns immediately; work runs on a background task.
+pub async fn generate_image_embeddings(
+    State(state): State<Arc<AppState>>,
+    Json(payload): Json<GenerateEmbeddingsRequest>,
+) -> Result<Json<GenerateEmbeddingsResponse>> {
+    let batch_size = payload.batch_size.unwrap_or(50);
+
+    let pending = state.db.get_frames_without_image_embeddings(1).await?;
+    if pending.is_empty() {
+        return Ok(Json(GenerateEmbeddingsResponse {
+            success: true,
+            message: "All frames already have image embeddings".to_string(),
+            frames_processed: 0,
+        }));
+    }
+
+    if IMAGE_EMBEDDING_JOB_RUNNING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        return Ok(Json(GenerateEmbeddingsResponse {
+            success: true,
+            message: "Image embedding generation is already running in the background".to_string(),
+            frames_processed: 0,
+        }));
+    }
+
+    let job_state = Arc::clone(&state);
+    tokio::spawn(async move {
+        struct JobGuard;
+        impl Drop for JobGuard {
+            fn drop(&mut self) {
+                IMAGE_EMBEDDING_JOB_RUNNING.store(false, Ordering::SeqCst);
+            }
+        }
+        let _guard = JobGuard;
+
+        let processed = run_image_embedding_job(&job_state, batch_size).await;
+        info!(
+            "Background image embedding job finished: {} frame(s) processed",
+            processed
+        );
+    });
+
+    Ok(Json(GenerateEmbeddingsResponse {
+        success: true,
+        message: "Image embedding generation started in the background".to_string(),
+        frames_processed: 0,
+    }))
+}
+
+/// Drain the image-embedding backlog in batches. Returns the number of frames
+/// embedded.
+async fn run_image_embedding_job(state: &Arc<AppState>, batch_size: i64) -> i64 {
+    let engine = match state.get_image_embedding_engine().await {
+        Ok(engine) => engine,
+        Err(error) => {
+            warn!("Failed to initialize image embedding engine: {}", error);
+            return 0;
+        }
+    };
+
+    let worker = crate::workers::image_embedding_worker::ImageEmbeddingWorker::new(
+        Arc::clone(&state.db),
+        engine,
+        crate::workers::image_embedding_worker::ImageEmbeddingWorkerConfig {
+            batch_size,
+            interval_secs: 60,
+        },
+    );
+
+    let mut total: i64 = 0;
+    loop {
+        match worker.process_batch().await {
+            Ok(0) => break,
+            Ok(count) => total += count as i64,
+            Err(error) => {
+                warn!("Image embedding batch failed: {}", error);
+                break;
+            }
+        }
+    }
+    total
+}
+
+/// POST /embeddings/image/enable — enable or disable the image-embedding index.
+pub async fn toggle_image_embeddings(
+    State(state): State<Arc<AppState>>,
+    Json(enabled): Json<bool>,
+) -> Result<Json<EmbeddingStatusResponse>> {
+    debug!("Setting image embeddings enabled: {}", enabled);
+
+    state
+        .db
+        .set_metadata(
+            "image_embeddings_enabled",
+            if enabled { "true" } else { "false" },
+        )
+        .await?;
+
+    get_image_embedding_status(State(state)).await
+}

--- a/screensearch-api/src/handlers/rag_helpers.rs
+++ b/screensearch-api/src/handlers/rag_helpers.rs
@@ -103,6 +103,7 @@ pub async fn retrieve_rag_results(
         .hybrid_search(
             user_query,
             query_embedding,
+            None,
             MAX_RAG_RESULTS,
             start_time,
             end_time,

--- a/screensearch-api/src/handlers/search.rs
+++ b/screensearch-api/src/handlers/search.rs
@@ -76,9 +76,24 @@ pub async fn search(
             .unwrap_or(chrono::DateTime::<chrono::Utc>::MIN_UTC);
         let end_time = params.end_time.unwrap_or_else(chrono::Utc::now);
         let mut semantic_results = if mode == "hybrid" {
+            // Fuse the image-embedding index when its engine is already warm
+            // (loaded because image embeddings are enabled). The query is encoded
+            // with the aligned nomic-text encoder; we never block search on a
+            // first-run model load.
+            let image_embedding = match state.image_embedding_engine_if_ready().await {
+                Some(image_engine) => image_engine.embed_query(&params.q).await.ok(),
+                None => None,
+            };
             state
                 .db
-                .hybrid_search(&params.q, embedding, pagination.limit, start_time, end_time)
+                .hybrid_search(
+                    &params.q,
+                    embedding,
+                    image_embedding,
+                    pagination.limit,
+                    start_time,
+                    end_time,
+                )
                 .await
                 .map_err(AppError::Database)?
         } else {

--- a/screensearch-api/src/routes.rs
+++ b/screensearch-api/src/routes.rs
@@ -183,6 +183,10 @@ fn embeddings_routes() -> Router<Arc<AppState>> {
         .route("/models/prepare", post(handlers::prepare_quality_models))
         .route("/generate", post(handlers::generate_embeddings))
         .route("/enable", post(handlers::toggle_embeddings))
+        // Image-embedding (visual recall) index.
+        .route("/image/status", get(handlers::get_image_embedding_status))
+        .route("/image/generate", post(handlers::generate_image_embeddings))
+        .route("/image/enable", post(handlers::toggle_image_embeddings))
 }
 
 /// Vision analysis routes

--- a/screensearch-api/src/server.rs
+++ b/screensearch-api/src/server.rs
@@ -178,6 +178,64 @@ impl ApiServer {
         Ok(())
     }
 
+    /// Start the background image-embedding worker (visual recall).
+    ///
+    /// Always spawns the loop, but only loads the nomic image models and processes
+    /// frames while the `image_embeddings_enabled` runtime flag is set — so the API
+    /// toggle takes effect without a restart and the heavy models stay opt-in. The
+    /// engine is loaded lazily on the first enabled tick (and cached thereafter).
+    pub async fn start_image_embedding_worker(
+        &self,
+        config: crate::workers::image_embedding_worker::ImageEmbeddingWorkerConfig,
+    ) -> anyhow::Result<()> {
+        let state = Arc::clone(&self.state);
+        let interval_secs = config.interval_secs.max(1);
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(std::time::Duration::from_secs(interval_secs));
+            let mut worker: Option<crate::workers::image_embedding_worker::ImageEmbeddingWorker> =
+                None;
+            loop {
+                tick.tick().await;
+
+                let enabled = matches!(
+                    state.db.get_metadata("image_embeddings_enabled").await,
+                    Ok(Some(value)) if value == "true"
+                );
+                if !enabled {
+                    continue;
+                }
+
+                // Lazy-load the image engine on first enabled tick.
+                if worker.is_none() {
+                    match state.get_image_embedding_engine().await {
+                        Ok(engine) => {
+                            tracing::info!("Starting background image embedding worker");
+                            worker = Some(
+                                crate::workers::image_embedding_worker::ImageEmbeddingWorker::new(
+                                    Arc::clone(&state.db),
+                                    engine,
+                                    config.clone(),
+                                ),
+                            );
+                        }
+                        Err(error) => {
+                            tracing::warn!("Image embedding engine unavailable: {}", error);
+                            continue;
+                        }
+                    }
+                }
+
+                if let Some(worker) = worker.as_ref() {
+                    if let Err(error) = worker.process_batch().await {
+                        tracing::error!("Image embedding worker error: {}", error);
+                    }
+                }
+            }
+        });
+
+        Ok(())
+    }
+
     /// Start the background vision analysis worker.
     ///
     /// The worker shares the API server's `AppState` so it can drive the unified
@@ -193,6 +251,17 @@ impl ApiServer {
             .set_metadata("embeddings_enabled", if enabled { "true" } else { "false" })
             .await
             .map_err(|error| anyhow::anyhow!("Failed to update embedding state: {error}"))
+    }
+
+    pub async fn set_image_embeddings_enabled(&self, enabled: bool) -> anyhow::Result<()> {
+        self.state
+            .db
+            .set_metadata(
+                "image_embeddings_enabled",
+                if enabled { "true" } else { "false" },
+            )
+            .await
+            .map_err(|error| anyhow::anyhow!("Failed to update image embedding state: {error}"))
     }
 }
 

--- a/screensearch-api/src/state.rs
+++ b/screensearch-api/src/state.rs
@@ -2,7 +2,7 @@
 
 use screensearch_automation::AutomationEngine;
 use screensearch_db::DatabaseManager;
-use screensearch_embeddings::{EmbeddingEngine, EMBEDDING_DIM};
+use screensearch_embeddings::{EmbeddingEngine, ImageEmbeddingEngine, EMBEDDING_DIM};
 use screensearch_llm::LlamaServer;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -60,6 +60,10 @@ pub struct AppState {
     /// Embedding engine for semantic search (lazy initialized)
     pub embedding_engine: Arc<RwLock<Option<Arc<EmbeddingEngine>>>>,
 
+    /// Image-embedding engine for visual recall (lazy initialized; only loaded
+    /// when image embeddings are enabled).
+    pub image_embedding_engine: Arc<RwLock<Option<Arc<ImageEmbeddingEngine>>>>,
+
     /// Shared capture interval in milliseconds (atomic for thread safety)
     pub capture_interval_ms: Arc<std::sync::atomic::AtomicU64>,
 
@@ -88,6 +92,7 @@ impl AppState {
             db: Arc::new(db),
             automation: Arc::new(automation),
             embedding_engine: Arc::new(RwLock::new(None)),
+            image_embedding_engine: Arc::new(RwLock::new(None)),
             capture_interval_ms,
             monitor_config_tx,
             llama_server: Arc::new(RwLock::new(None)),
@@ -134,6 +139,60 @@ impl AppState {
         let engine = EmbeddingEngine::new().await.map_err(|e| e.to_string())?;
         self.db
             .ensure_embedding_model(
+                engine.provider(),
+                engine.model(),
+                engine.model_version(),
+                EMBEDDING_DIM,
+            )
+            .await
+            .map_err(|e| e.to_string())?;
+        let engine_arc = Arc::new(engine);
+        *guard = Some(Arc::clone(&engine_arc));
+
+        Ok(engine_arc)
+    }
+
+    /// Whether the in-process image-embedding engine has already been loaded.
+    pub async fn image_embedding_engine_initialized(&self) -> bool {
+        match self.image_embedding_engine.try_read() {
+            Ok(guard) => guard.is_some(),
+            Err(_) => false,
+        }
+    }
+
+    /// Return the image-embedding engine only if it is already loaded, without
+    /// triggering a (potentially slow first-run) load. Used on the search path so
+    /// image fusion never blocks a query on a model download.
+    pub async fn image_embedding_engine_if_ready(&self) -> Option<Arc<ImageEmbeddingEngine>> {
+        self.image_embedding_engine
+            .read()
+            .await
+            .as_ref()
+            .map(Arc::clone)
+    }
+
+    /// Get or initialize the image-embedding engine (nomic vision + text).
+    ///
+    /// Mirrors [`Self::get_embedding_engine`]: serialized first-use init behind a
+    /// write lock, and validates the image-vector model contract on first load.
+    pub async fn get_image_embedding_engine(&self) -> Result<Arc<ImageEmbeddingEngine>, String> {
+        {
+            let guard = self.image_embedding_engine.read().await;
+            if let Some(engine) = guard.as_ref() {
+                return Ok(Arc::clone(engine));
+            }
+        }
+
+        let mut guard = self.image_embedding_engine.write().await;
+        if let Some(engine) = guard.as_ref() {
+            return Ok(Arc::clone(engine));
+        }
+
+        let engine = ImageEmbeddingEngine::new()
+            .await
+            .map_err(|e| e.to_string())?;
+        self.db
+            .ensure_image_embedding_model(
                 engine.provider(),
                 engine.model(),
                 engine.model_version(),

--- a/screensearch-api/src/state.rs
+++ b/screensearch-api/src/state.rs
@@ -163,12 +163,15 @@ impl AppState {
     /// Return the image-embedding engine only if it is already loaded, without
     /// triggering a (potentially slow first-run) load. Used on the search path so
     /// image fusion never blocks a query on a model download.
+    ///
+    /// Uses `try_read` (not `read().await`): `get_image_embedding_engine` holds the
+    /// write lock for the whole first-run model download, and a search query must
+    /// never block on that — a held write lock simply means "not ready yet".
     pub async fn image_embedding_engine_if_ready(&self) -> Option<Arc<ImageEmbeddingEngine>> {
         self.image_embedding_engine
-            .read()
-            .await
-            .as_ref()
-            .map(Arc::clone)
+            .try_read()
+            .ok()
+            .and_then(|guard| guard.as_ref().map(Arc::clone))
     }
 
     /// Get or initialize the image-embedding engine (nomic vision + text).

--- a/screensearch-api/src/workers/image_embedding_worker.rs
+++ b/screensearch-api/src/workers/image_embedding_worker.rs
@@ -83,6 +83,14 @@ impl ImageEmbeddingWorker {
                 }
             };
             let Some(embedding) = vectors.into_iter().next() else {
+                // No vector for a valid path: advance the cursor so this frame
+                // isn't re-fetched forever (the query filters on f.id > cursor).
+                self.db
+                    .set_metadata(
+                        "image_embeddings_last_processed_frame_id",
+                        &frame.id.to_string(),
+                    )
+                    .await?;
                 continue;
             };
 
@@ -93,6 +101,10 @@ impl ImageEmbeddingWorker {
                     self.engine.provider(),
                     self.engine.model(),
                     self.engine.model_version(),
+                    // Hashes the file path, not the pixels: identifies which frame
+                    // the vector belongs to, not whether the image bytes changed.
+                    // Re-embedding is driven by model-contract changes
+                    // (ensure_image_embedding_model), not silent file edits.
                     &EmbeddingEngine::content_hash(&frame.file_path),
                 )
                 .await?;

--- a/screensearch-api/src/workers/image_embedding_worker.rs
+++ b/screensearch-api/src/workers/image_embedding_worker.rs
@@ -1,0 +1,123 @@
+//! Background image-embedding worker.
+//!
+//! Embeds stored screenshots (by `file_path`) with the in-process nomic vision
+//! model into the separate image-embedding index, so text queries can retrieve
+//! frames by their pixels. Mirrors the text [`super::embedding_worker`]; gated at
+//! runtime by the `image_embeddings_enabled` metadata flag.
+
+use screensearch_db::DatabaseManager;
+use screensearch_embeddings::{EmbeddingEngine, ImageEmbeddingEngine};
+use std::sync::Arc;
+use tracing::{debug, info, warn};
+
+/// Configuration for the background image-embedding worker.
+///
+/// The worker loop is always spawned but gated at runtime by the
+/// `image_embeddings_enabled` metadata flag (so the API toggle takes effect
+/// without a restart, and the models load lazily only when enabled).
+#[derive(Debug, Clone)]
+pub struct ImageEmbeddingWorkerConfig {
+    pub batch_size: i64,
+    pub interval_secs: u64,
+}
+
+impl Default for ImageEmbeddingWorkerConfig {
+    fn default() -> Self {
+        Self {
+            batch_size: 16,
+            interval_secs: 60,
+        }
+    }
+}
+
+/// Background worker for generating image embeddings.
+pub struct ImageEmbeddingWorker {
+    db: Arc<DatabaseManager>,
+    engine: Arc<ImageEmbeddingEngine>,
+    config: ImageEmbeddingWorkerConfig,
+}
+
+impl ImageEmbeddingWorker {
+    pub fn new(
+        db: Arc<DatabaseManager>,
+        engine: Arc<ImageEmbeddingEngine>,
+        config: ImageEmbeddingWorkerConfig,
+    ) -> Self {
+        Self { db, engine, config }
+    }
+
+    /// Process a batch of frames that lack an image embedding.
+    pub async fn process_batch(&self) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+        let frames = self
+            .db
+            .get_frames_without_image_embeddings(self.config.batch_size)
+            .await?;
+        if frames.is_empty() {
+            debug!("No frames to image-embed");
+            return Ok(0);
+        }
+
+        info!("Processing {} frames for image embeddings", frames.len());
+        let mut processed = 0;
+
+        for frame in frames {
+            // Embed one frame at a time so a missing/corrupt screenshot only skips
+            // that frame instead of failing the whole batch.
+            let vectors = match self
+                .engine
+                .embed_images(vec![frame.file_path.clone()])
+                .await
+            {
+                Ok(v) => v,
+                Err(e) => {
+                    warn!("Failed to image-embed frame {}: {}", frame.id, e);
+                    // Advance the cursor so a persistently-bad frame doesn't wedge
+                    // the worker on every tick.
+                    self.db
+                        .set_metadata(
+                            "image_embeddings_last_processed_frame_id",
+                            &frame.id.to_string(),
+                        )
+                        .await?;
+                    continue;
+                }
+            };
+            let Some(embedding) = vectors.into_iter().next() else {
+                continue;
+            };
+
+            self.db
+                .insert_image_embedding(
+                    frame.id,
+                    embedding,
+                    self.engine.provider(),
+                    self.engine.model(),
+                    self.engine.model_version(),
+                    &EmbeddingEngine::content_hash(&frame.file_path),
+                )
+                .await?;
+            processed += 1;
+
+            self.db
+                .set_metadata(
+                    "image_embeddings_last_processed_frame_id",
+                    &frame.id.to_string(),
+                )
+                .await?;
+        }
+
+        if processed > 0
+            && self
+                .db
+                .get_frames_without_image_embeddings(1)
+                .await?
+                .is_empty()
+        {
+            self.db
+                .set_metadata("image_embeddings_reindex_required", "false")
+                .await?;
+        }
+        info!("Image-embedded {} frames", processed);
+        Ok(processed)
+    }
+}

--- a/screensearch-api/src/workers/mod.rs
+++ b/screensearch-api/src/workers/mod.rs
@@ -1,6 +1,8 @@
 //! Background workers module
 
 pub mod embedding_worker;
+pub mod image_embedding_worker;
 pub mod vision_worker;
 
 pub use embedding_worker::{spawn_embedding_worker, EmbeddingWorker, EmbeddingWorkerConfig};
+pub use image_embedding_worker::{ImageEmbeddingWorker, ImageEmbeddingWorkerConfig};

--- a/screensearch-db/src/migrations.rs
+++ b/screensearch-db/src/migrations.rs
@@ -70,6 +70,7 @@ pub async fn run_migrations(pool: &Pool<Sqlite>) -> Result<()> {
         MIGRATION_012_QWEN3VL_VISION_DEFAULT,
     )
     .await?;
+    apply_migration(pool, "013_image_embeddings", MIGRATION_013_IMAGE_EMBEDDINGS).await?;
 
     tracing::info!("All migrations completed successfully");
     Ok(())
@@ -331,6 +332,50 @@ INSERT OR REPLACE INTO metadata (key, value) VALUES
     ('embeddings_dimension', '768'),
     ('embeddings_last_processed_frame_id', '0'),
     ('embeddings_reindex_required', 'true');
+"#;
+
+/// In-process image embeddings (nomic-embed-vision-v1.5, 768-dim) for visual recall.
+///
+/// Kept in a SEPARATE table + sqlite-vec index from the text `embeddings`: image
+/// vectors live in a different (nomic) latent space than the EmbeddingGemma text
+/// vectors, so a single KNN across both would be meaningless. The image index is
+/// queried with its own (nomic-text) query encoder and fused with text results by
+/// rank (RRF) at search time. One whole-frame embedding per frame (no chunking).
+const MIGRATION_013_IMAGE_EMBEDDINGS: &str = r#"
+CREATE TABLE IF NOT EXISTS image_embeddings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    frame_id INTEGER NOT NULL,
+    embedding BLOB NOT NULL,
+    embedding_dim INTEGER NOT NULL DEFAULT 768,
+    provider TEXT NOT NULL DEFAULT 'unknown',
+    model TEXT NOT NULL DEFAULT 'unknown',
+    model_version TEXT NOT NULL DEFAULT 'unknown',
+    content_hash TEXT NOT NULL DEFAULT '',
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (frame_id) REFERENCES frames(id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_image_embeddings_frame
+ON image_embeddings(frame_id);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS image_embedding_vectors USING vec0(
+    embedding_id INTEGER PRIMARY KEY,
+    embedding float[768] distance_metric=cosine
+);
+
+CREATE TRIGGER IF NOT EXISTS image_embeddings_vector_delete
+AFTER DELETE ON image_embeddings BEGIN
+    DELETE FROM image_embedding_vectors WHERE embedding_id = old.id;
+END;
+
+INSERT OR REPLACE INTO metadata (key, value) VALUES
+    ('image_embeddings_model', 'nomic-embed-vision-v1.5'),
+    ('image_embeddings_provider', 'fastembed'),
+    ('image_embeddings_model_version', '1'),
+    ('image_embeddings_dimension', '768'),
+    ('image_embeddings_last_processed_frame_id', '0'),
+    ('image_embeddings_reindex_required', 'true'),
+    ('image_embeddings_enabled', 'false');
 "#;
 
 /// Prevent concurrent or repeated indexing from duplicating frame chunks.

--- a/screensearch-db/src/queries.rs
+++ b/screensearch-db/src/queries.rs
@@ -1438,6 +1438,346 @@ impl DatabaseManager {
     }
 
     /// Get embedding status statistics
+    /// Insert (replacing any existing) the single whole-frame image embedding for
+    /// a frame, into both the `image_embeddings` metadata table and the
+    /// `image_embedding_vectors` sqlite-vec index, in one transaction.
+    pub async fn insert_image_embedding(
+        &self,
+        frame_id: i64,
+        embedding: Vec<f32>,
+        provider: &str,
+        model: &str,
+        model_version: &str,
+        content_hash: &str,
+    ) -> Result<i64> {
+        let embedding_blob: Vec<u8> = embedding.iter().flat_map(|f| f.to_le_bytes()).collect();
+
+        let mut tx = self.pool().begin().await?;
+        // One image embedding per frame; replace on re-index. The delete trigger
+        // cascades into image_embedding_vectors.
+        sqlx::query("DELETE FROM image_embeddings WHERE frame_id = ?")
+            .bind(frame_id)
+            .execute(&mut *tx)
+            .await?;
+
+        let result = sqlx::query(
+            r#"
+            INSERT INTO image_embeddings (
+                frame_id, embedding, embedding_dim, provider, model, model_version, content_hash
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            "#,
+        )
+        .bind(frame_id)
+        .bind(&embedding_blob)
+        .bind(embedding.len() as i32)
+        .bind(provider)
+        .bind(model)
+        .bind(model_version)
+        .bind(content_hash)
+        .execute(&mut *tx)
+        .await?;
+        let embedding_id = result.last_insert_rowid();
+
+        sqlx::query("INSERT INTO image_embedding_vectors (embedding_id, embedding) VALUES (?, ?)")
+            .bind(embedding_id)
+            .bind(embedding_blob)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(embedding_id)
+    }
+
+    /// Get frames that don't have an image embedding yet (for background
+    /// processing). Unlike text embedding, this has no OCR requirement — image
+    /// recall must work for frames with little/no on-screen text — but the frame
+    /// must reference a stored screenshot (`file_path`).
+    pub async fn get_frames_without_image_embeddings(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<FrameRecord>> {
+        let frames = sqlx::query_as::<_, FrameRecord>(
+            r#"
+            SELECT f.id, f.chunk_id, f.timestamp, f.monitor_index, f.device_name,
+                   f.file_path, f.active_window, f.active_process, f.browser_url,
+                   f.width, f.height, f.offset_index, f.focused, f.created_at,
+                   f.analysis_status, f.description, f.visible_text_json, f.activity_type,
+                   f.app_hint, f.confidence, f.analysis_time_ms, f.analysis_error
+            FROM frames f
+            LEFT JOIN image_embeddings ie ON f.id = ie.frame_id
+            WHERE ie.id IS NULL
+              AND f.file_path IS NOT NULL
+              AND TRIM(f.file_path) <> ''
+            ORDER BY f.id ASC
+            LIMIT ?
+            "#,
+        )
+        .bind(limit)
+        .fetch_all(self.pool())
+        .await?;
+
+        Ok(frames)
+    }
+
+    /// KNN search over the image-embedding index. The query vector must come from
+    /// the paired nomic-text encoder (the image vectors are nomic-vision, a
+    /// different space than the EmbeddingGemma text index). Returns one result per
+    /// matching frame; `chunk_text` carries the frame's vision description (for
+    /// display / RRF keying) and `chunk_index` is -1.
+    pub async fn search_image_embeddings_with_time_range(
+        &self,
+        query_vector: Vec<f32>,
+        limit: usize,
+        min_score: f32,
+        start_time: Option<DateTime<Utc>>,
+        end_time: Option<DateTime<Utc>>,
+    ) -> Result<Vec<SemanticResult>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        if query_vector.len() != EMBEDDING_DIM {
+            return Err(crate::DatabaseError::InvalidParameter(format!(
+                "Expected a {EMBEDDING_DIM}-dimensional query vector, got {}",
+                query_vector.len()
+            )));
+        }
+
+        let query_blob: Vec<u8> = query_vector
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect();
+        let total_vectors =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM image_embedding_vectors")
+                .fetch_one(self.pool())
+                .await?;
+        if total_vectors == 0 {
+            return Ok(Vec::new());
+        }
+
+        let base_query = r#"
+            WITH nearest AS (
+                SELECT embedding_id, distance
+                FROM image_embedding_vectors
+                WHERE embedding MATCH ?
+                ORDER BY distance
+                LIMIT ?
+            )
+            SELECT ie.frame_id,
+                   f.timestamp, f.monitor_index, f.device_name, f.file_path,
+                   f.active_window, f.active_process, f.browser_url, f.width, f.height,
+                   f.offset_index, f.focused, f.created_at,
+                   f.analysis_status, f.description, f.visible_text_json, f.activity_type,
+                   f.app_hint, f.confidence, f.analysis_time_ms, f.analysis_error,
+                   nearest.distance
+            FROM nearest
+            JOIN image_embeddings ie ON ie.id = nearest.embedding_id
+            JOIN frames f ON ie.frame_id = f.id
+        "#;
+
+        let mut conditions = Vec::new();
+        if start_time.is_some() {
+            conditions.push("f.timestamp >= ?");
+        }
+        if end_time.is_some() {
+            conditions.push("f.timestamp <= ?");
+        }
+        let query = if conditions.is_empty() {
+            base_query.to_string()
+        } else {
+            format!("{} WHERE {}", base_query, conditions.join(" AND "))
+        };
+
+        let filtered = start_time.is_some() || end_time.is_some();
+        let initial_limit = if filtered {
+            limit.saturating_mul(12).max(100)
+        } else {
+            limit
+        };
+        let expanded_limit = limit.saturating_mul(100).max(initial_limit);
+        let candidate_limits = [initial_limit, expanded_limit, total_vectors as usize];
+        let mut rows = Vec::new();
+
+        for requested_limit in candidate_limits {
+            let candidate_limit = requested_limit.min(total_vectors as usize).max(limit) as i64;
+            let mut query_builder = sqlx::query(&query).bind(&query_blob).bind(candidate_limit);
+            if let Some(start) = &start_time {
+                query_builder = query_builder.bind(start);
+            }
+            if let Some(end) = &end_time {
+                query_builder = query_builder.bind(end);
+            }
+            rows = query_builder.fetch_all(self.pool()).await?;
+            if !filtered || rows.len() >= limit || candidate_limit >= total_vectors {
+                break;
+            }
+        }
+
+        let mut candidates: Vec<SemanticResult> = Vec::new();
+        for row in rows {
+            let distance: f32 = row.get("distance");
+            let similarity = 1.0 - distance;
+            if similarity < min_score {
+                continue;
+            }
+            let description: Option<String> = row.try_get("description").ok();
+            let frame = FrameRecord {
+                id: row.get("frame_id"),
+                chunk_id: None,
+                timestamp: row.get("timestamp"),
+                monitor_index: row.get("monitor_index"),
+                device_name: row.get("device_name"),
+                file_path: row.get("file_path"),
+                active_window: row.get("active_window"),
+                active_process: row.get("active_process"),
+                browser_url: row.get("browser_url"),
+                width: row.get("width"),
+                height: row.get("height"),
+                offset_index: row.get("offset_index"),
+                focused: row.get("focused"),
+                created_at: row.get::<DateTime<Utc>, _>("created_at"),
+                analysis_status: row.try_get("analysis_status").ok(),
+                description: description.clone(),
+                visible_text_json: row.try_get("visible_text_json").ok(),
+                activity_type: row.try_get("activity_type").ok(),
+                app_hint: row.try_get("app_hint").ok(),
+                confidence: row.try_get("confidence").ok(),
+                analysis_time_ms: row.try_get("analysis_time_ms").ok(),
+                analysis_error: row.try_get("analysis_error").ok(),
+            };
+            candidates.push(SemanticResult {
+                frame,
+                chunk_text: description.unwrap_or_default(),
+                chunk_index: -1,
+                similarity_score: similarity,
+                retrieval_source: "image".to_string(),
+            });
+        }
+
+        candidates.sort_by(|a, b| {
+            b.similarity_score
+                .partial_cmp(&a.similarity_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        Ok(candidates.into_iter().take(limit).collect())
+    }
+
+    /// Status of the image-embedding index (coverage over all stored frames).
+    pub async fn get_image_embedding_status(&self) -> Result<EmbeddingStatus> {
+        let total_frames = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM frames WHERE file_path IS NOT NULL AND TRIM(file_path) <> ''",
+        )
+        .fetch_one(self.pool())
+        .await?;
+
+        let frames_with_embeddings =
+            sqlx::query_scalar::<_, i64>("SELECT COUNT(DISTINCT frame_id) FROM image_embeddings")
+                .fetch_one(self.pool())
+                .await?;
+
+        let enabled = self
+            .get_metadata("image_embeddings_enabled")
+            .await?
+            .map(|v| v == "true")
+            .unwrap_or(false);
+        let model = self
+            .get_metadata("image_embeddings_model")
+            .await?
+            .unwrap_or_else(|| "nomic-embed-vision-v1.5".to_string());
+        let provider = self
+            .get_metadata("image_embeddings_provider")
+            .await?
+            .unwrap_or_else(|| "unknown".to_string());
+        let model_version = self
+            .get_metadata("image_embeddings_model_version")
+            .await?
+            .unwrap_or_else(|| "unknown".to_string());
+        let dimension = self
+            .get_metadata("image_embeddings_dimension")
+            .await?
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(0);
+        let reindex_required = self
+            .get_metadata("image_embeddings_reindex_required")
+            .await?
+            .map(|value| value == "true")
+            .unwrap_or(false);
+        let last_processed_frame_id = self
+            .get_metadata("image_embeddings_last_processed_frame_id")
+            .await?
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+
+        let coverage_percent = if total_frames > 0 {
+            (frames_with_embeddings as f32 / total_frames as f32) * 100.0
+        } else {
+            0.0
+        };
+
+        Ok(EmbeddingStatus {
+            enabled,
+            model,
+            provider,
+            model_version,
+            dimension,
+            reindex_required,
+            total_frames,
+            frames_with_embeddings,
+            coverage_percent,
+            last_processed_frame_id,
+        })
+    }
+
+    /// Invalidate the image-embedding index when its model contract changes.
+    pub async fn ensure_image_embedding_model(
+        &self,
+        provider: &str,
+        model: &str,
+        model_version: &str,
+        dimension: usize,
+    ) -> Result<bool> {
+        let current_provider = self.get_metadata("image_embeddings_provider").await?;
+        let current_model = self.get_metadata("image_embeddings_model").await?;
+        let current_version = self.get_metadata("image_embeddings_model_version").await?;
+        let current_dimension = self.get_metadata("image_embeddings_dimension").await?;
+        let expected_dimension = dimension.to_string();
+
+        if current_provider.as_deref() == Some(provider)
+            && current_model.as_deref() == Some(model)
+            && current_version.as_deref() == Some(model_version)
+            && current_dimension.as_deref() == Some(expected_dimension.as_str())
+        {
+            return Ok(false);
+        }
+
+        let mut tx = self.pool().begin().await?;
+        sqlx::query("DELETE FROM image_embedding_vectors")
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM image_embeddings")
+            .execute(&mut *tx)
+            .await?;
+        for (key, value) in [
+            ("image_embeddings_provider", provider),
+            ("image_embeddings_model", model),
+            ("image_embeddings_model_version", model_version),
+            ("image_embeddings_dimension", expected_dimension.as_str()),
+            ("image_embeddings_last_processed_frame_id", "0"),
+            ("image_embeddings_reindex_required", "true"),
+        ] {
+            sqlx::query(
+                "INSERT INTO metadata (key, value) VALUES (?, ?) \
+                 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = CURRENT_TIMESTAMP",
+            )
+            .bind(key)
+            .bind(value)
+            .execute(&mut *tx)
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(true)
+    }
+
     pub async fn get_embedding_status(&self) -> Result<EmbeddingStatus> {
         let total_frames =
             sqlx::query_scalar::<_, i64>("SELECT COUNT(DISTINCT frame_id) FROM ocr_text")

--- a/screensearch-db/src/queries.rs
+++ b/screensearch-db/src/queries.rs
@@ -1493,10 +1493,23 @@ impl DatabaseManager {
     /// processing). Unlike text embedding, this has no OCR requirement — image
     /// recall must work for frames with little/no on-screen text — but the frame
     /// must reference a stored screenshot (`file_path`).
+    ///
+    /// Filters on `f.id > image_embeddings_last_processed_frame_id` so the worker
+    /// makes forward progress: a frame that fails to embed (corrupt/missing file)
+    /// is not re-fetched on every batch/tick (the worker advances the cursor past
+    /// it), and the query is a bounded forward scan rather than a full table scan.
+    /// The cursor is reset to 0 by `ensure_image_embedding_model` on a model
+    /// change, which triggers a full re-index.
     pub async fn get_frames_without_image_embeddings(
         &self,
         limit: i64,
     ) -> Result<Vec<FrameRecord>> {
+        let last_id = self
+            .get_metadata("image_embeddings_last_processed_frame_id")
+            .await?
+            .and_then(|v| v.parse::<i64>().ok())
+            .unwrap_or(0);
+
         let frames = sqlx::query_as::<_, FrameRecord>(
             r#"
             SELECT f.id, f.chunk_id, f.timestamp, f.monitor_index, f.device_name,
@@ -1506,13 +1519,15 @@ impl DatabaseManager {
                    f.app_hint, f.confidence, f.analysis_time_ms, f.analysis_error
             FROM frames f
             LEFT JOIN image_embeddings ie ON f.id = ie.frame_id
-            WHERE ie.id IS NULL
+            WHERE f.id > ?
+              AND ie.id IS NULL
               AND f.file_path IS NOT NULL
               AND TRIM(f.file_path) <> ''
             ORDER BY f.id ASC
             LIMIT ?
             "#,
         )
+        .bind(last_id)
         .bind(limit)
         .fetch_all(self.pool())
         .await?;

--- a/screensearch-db/src/vector_search.rs
+++ b/screensearch-db/src/vector_search.rs
@@ -42,11 +42,17 @@ impl DatabaseManager {
         .await
     }
 
-    /// Hybrid search combining FTS5 and vector similarity
+    /// Hybrid search combining FTS5 and vector similarity.
+    ///
+    /// When `image_query_embedding` is provided (a nomic-text vector aligned with
+    /// the image index), image-embedding hits are fused in as a third ranked list
+    /// via the same Reciprocal Rank Fusion, giving non-OCR visual content a path
+    /// into the results. Pass `None` to skip the image index entirely.
     pub async fn hybrid_search(
         &self,
         query: &str,
         query_embedding: Vec<f32>,
+        image_query_embedding: Option<Vec<f32>>,
         limit: i64,
         start_time: DateTime<Utc>,
         end_time: DateTime<Utc>,
@@ -110,6 +116,44 @@ impl DatabaseManager {
                         chunk_index: -1,
                         similarity_score: score_boost,
                         retrieval_source: "fts".to_string(),
+                    });
+            }
+        }
+
+        // Optional third list: image-embedding hits (queried with the aligned
+        // nomic-text vector), fused with the same RRF formula. Image vectors live
+        // in a separate space, so they come only from the image index.
+        if let Some(image_embedding) = image_query_embedding {
+            let image_results = match self
+                .search_image_embeddings_with_time_range(
+                    image_embedding,
+                    candidate_limit.max(0) as usize,
+                    0.0,
+                    Some(start_time),
+                    Some(end_time),
+                )
+                .await
+            {
+                Ok(res) => res,
+                Err(e) => {
+                    tracing::error!("Image search failed: {}", e);
+                    Vec::new()
+                }
+            };
+
+            for (rank, res) in image_results.into_iter().enumerate() {
+                let key = (res.frame.id, res.chunk_text.clone());
+                let score_boost = 1.0 / (RRF_K + rank as f32 + 1.0);
+                merged
+                    .entry(key)
+                    .and_modify(|result| {
+                        result.similarity_score += score_boost;
+                        result.retrieval_source = "hybrid".to_string();
+                    })
+                    .or_insert_with(|| SemanticResult {
+                        similarity_score: score_boost,
+                        retrieval_source: "image".to_string(),
+                        ..res
                     });
             }
         }

--- a/screensearch-db/tests/integration_tests.rs
+++ b/screensearch-db/tests/integration_tests.rs
@@ -1178,3 +1178,40 @@ async fn test_hybrid_search_fuses_image_results() {
 
     db.close().await;
 }
+
+/// The image-embedding cursor (`image_embeddings_last_processed_frame_id`) makes
+/// get_frames_without_image_embeddings skip frames at or below the cursor, so a
+/// frame that failed to embed is not re-fetched forever.
+#[tokio::test]
+async fn test_image_embedding_cursor_skips_processed_frames() {
+    let (db, _path) = create_test_db().await;
+
+    let f1 = db
+        .insert_frame(create_test_frame(Utc::now(), "app", "One"))
+        .await
+        .unwrap();
+    let f2 = db
+        .insert_frame(create_test_frame(Utc::now(), "app", "Two"))
+        .await
+        .unwrap();
+    let f3 = db
+        .insert_frame(create_test_frame(Utc::now(), "app", "Three"))
+        .await
+        .unwrap();
+
+    // No embeddings yet -> all three eligible.
+    let pending = db.get_frames_without_image_embeddings(10).await.unwrap();
+    assert_eq!(pending.len(), 3);
+
+    // Simulate the worker advancing the cursor past f2 (e.g. f1/f2 failed to
+    // embed). Only f3 should remain eligible — f1/f2 are not retried.
+    db.set_metadata("image_embeddings_last_processed_frame_id", &f2.to_string())
+        .await
+        .unwrap();
+    let pending = db.get_frames_without_image_embeddings(10).await.unwrap();
+    let ids: Vec<i64> = pending.iter().map(|f| f.id).collect();
+    assert_eq!(ids, vec![f3]);
+    assert!(!ids.contains(&f1) && !ids.contains(&f2));
+
+    db.close().await;
+}

--- a/screensearch-db/tests/integration_tests.rs
+++ b/screensearch-db/tests/integration_tests.rs
@@ -1022,3 +1022,159 @@ async fn test_vision_completion_without_description_keeps_embeddings() {
 
     db.close().await;
 }
+
+/// Image-embedding index: insert, KNN search, eligibility, replace, and
+/// model-contract invalidation.
+#[tokio::test]
+async fn test_image_embedding_insert_search_and_eligibility() {
+    let (db, _path) = create_test_db().await;
+
+    let f1 = db
+        .insert_frame(create_test_frame(Utc::now(), "a", "One"))
+        .await
+        .unwrap();
+    let f2 = db
+        .insert_frame(create_test_frame(Utc::now(), "b", "Two"))
+        .await
+        .unwrap();
+
+    let mut v1 = vec![0.0f32; 768];
+    v1[0] = 1.0;
+    let mut v2 = vec![0.0f32; 768];
+    v2[1] = 1.0;
+    db.insert_image_embedding(
+        f1,
+        v1.clone(),
+        "fastembed",
+        "nomic-embed-vision-v1.5",
+        "1",
+        "h1",
+    )
+    .await
+    .unwrap();
+    db.insert_image_embedding(f2, v2, "fastembed", "nomic-embed-vision-v1.5", "1", "h2")
+        .await
+        .unwrap();
+
+    // A query nearest v1 must rank frame 1 first, tagged as an image hit.
+    let mut q = vec![0.0f32; 768];
+    q[0] = 0.9;
+    q[1] = 0.1;
+    let results = db
+        .search_image_embeddings_with_time_range(q, 5, 0.0, None, None)
+        .await
+        .unwrap();
+    assert!(!results.is_empty());
+    assert_eq!(results[0].frame.id, f1);
+    assert_eq!(results[0].retrieval_source, "image");
+
+    // Both embedded -> not pending; a fresh frame is eligible (no OCR required).
+    let pending = db.get_frames_without_image_embeddings(10).await.unwrap();
+    assert!(!pending.iter().any(|f| f.id == f1 || f.id == f2));
+    let f3 = db
+        .insert_frame(create_test_frame(Utc::now(), "c", "Three"))
+        .await
+        .unwrap();
+    let pending = db.get_frames_without_image_embeddings(10).await.unwrap();
+    assert!(pending.iter().any(|f| f.id == f3));
+
+    // Re-inserting replaces (one image embedding per frame).
+    db.insert_image_embedding(f1, v1, "fastembed", "nomic-embed-vision-v1.5", "1", "h1b")
+        .await
+        .unwrap();
+    let status = db.get_image_embedding_status().await.unwrap();
+    assert_eq!(status.frames_with_embeddings, 2);
+
+    // A model-contract change clears the index and flags a reindex.
+    let changed = db
+        .ensure_image_embedding_model("fastembed", "other-model", "1", 768)
+        .await
+        .unwrap();
+    assert!(changed);
+    let status = db.get_image_embedding_status().await.unwrap();
+    assert_eq!(status.frames_with_embeddings, 0);
+
+    db.close().await;
+}
+
+/// hybrid_search fuses the image-embedding index: a textless frame (image
+/// embedding only) is retrievable when an image-query vector is supplied, and
+/// absent when it is not.
+#[tokio::test]
+async fn test_hybrid_search_fuses_image_results() {
+    let (db, _path) = create_test_db().await;
+
+    let a = db
+        .insert_frame(create_test_frame(Utc::now(), "app", "A"))
+        .await
+        .unwrap();
+    let b = db
+        .insert_frame(create_test_frame(Utc::now(), "app", "B"))
+        .await
+        .unwrap();
+
+    // Frame A: OCR text + a text (EmbeddingGemma-space) embedding.
+    db.insert_ocr_text(create_test_ocr(a, "alpha"))
+        .await
+        .unwrap();
+    let mut ta = vec![0.0f32; 768];
+    ta[0] = 1.0;
+    db.insert_embedding(NewEmbedding {
+        frame_id: a,
+        chunk_text: "alpha".to_string(),
+        chunk_index: 0,
+        embedding: ta.clone(),
+        provider: "fastembed".to_string(),
+        model: "EmbeddingGemma-300M".to_string(),
+        model_version: "1".to_string(),
+        content_hash: "a".to_string(),
+    })
+    .await
+    .unwrap();
+
+    // Frame B: textless — only an image (nomic-space) embedding.
+    let mut ib = vec![0.0f32; 768];
+    ib[5] = 1.0;
+    db.insert_image_embedding(
+        b,
+        ib.clone(),
+        "fastembed",
+        "nomic-embed-vision-v1.5",
+        "1",
+        "b",
+    )
+    .await
+    .unwrap();
+
+    let start = chrono::DateTime::<Utc>::MIN_UTC;
+    // Not MAX_UTC: its leading '+' sign breaks SQLite's lexicographic timestamp
+    // comparison. Production search uses `now()` for the end bound.
+    let end = Utc::now() + chrono::Duration::hours(1);
+
+    // With an image-query vector, the textless frame B is fused in.
+    let results = db
+        .hybrid_search("alpha", ta.clone(), Some(ib), 10, start, end)
+        .await
+        .unwrap();
+    let ids: Vec<i64> = results.iter().map(|r| r.frame.id).collect();
+    assert!(ids.contains(&a), "text-matched frame A should be present");
+    assert!(ids.contains(&b), "image-only frame B should be fused in");
+    let b_res = results.iter().find(|r| r.frame.id == b).unwrap();
+    assert!(
+        b_res.retrieval_source == "image" || b_res.retrieval_source == "hybrid",
+        "frame B should be tagged as an image/hybrid hit, got {}",
+        b_res.retrieval_source
+    );
+
+    // Without an image-query vector, the textless frame B does not appear.
+    let results_no_image = db
+        .hybrid_search("alpha", ta, None, 10, start, end)
+        .await
+        .unwrap();
+    assert!(
+        !results_no_image.iter().any(|r| r.frame.id == b),
+        "frame B must not appear without an image query"
+    );
+
+    db.close().await;
+}

--- a/screensearch-embeddings/Cargo.toml
+++ b/screensearch-embeddings/Cargo.toml
@@ -24,9 +24,15 @@ tracing = { workspace = true }
 # forced static-CRT + lld config (unresolved UCRT symbols), and dynamic loading
 # is the right model for a portable Windows binary that ships the DLL alongside
 # the exe. `hf-hub-native-tls` keeps first-run model download/caching.
+# `image-models` adds the multimodal image-embedding models (nomic-embed-vision)
+# used for the optional visual-recall index. It pulls in the `image` crate and its
+# codec deps (AV1/AVIF/etc.), which lengthen the build; the feature is always
+# compiled but the image engine only loads its model when image embeddings are
+# enabled at runtime.
 fastembed = { version = "5.17", default-features = false, features = [
     "ort-load-dynamic",
     "hf-hub-native-tls",
+    "image-models",
 ] }
 
 # Content hashing for chunk de-duplication

--- a/screensearch-embeddings/src/engine.rs
+++ b/screensearch-embeddings/src/engine.rs
@@ -18,7 +18,7 @@ const GEMMA_DOCUMENT_PREFIX: &str = "title: none | text: ";
 /// shipped next to the executable, when one is present and the caller hasn't
 /// already set `ORT_DYLIB_PATH`. If neither is set, `ort` falls back to its
 /// default platform search (e.g. the system `PATH`).
-fn configure_ort_dylib_path() {
+pub(crate) fn configure_ort_dylib_path() {
     use std::sync::Once;
     static INIT: Once = Once::new();
     INIT.call_once(|| {

--- a/screensearch-embeddings/src/image_engine.rs
+++ b/screensearch-embeddings/src/image_engine.rs
@@ -1,0 +1,147 @@
+//! In-process image-embedding engine for visual recall.
+//!
+//! Embeds screenshots with `nomic-embed-vision-v1.5` and image-search queries
+//! with `nomic-embed-text-v1.5`. The two models share a 768-dim latent space, so
+//! a text query can retrieve a matching screenshot directly from pixels — giving
+//! non-OCR visual content (charts, canvases, icon-heavy UIs) a recall path.
+//!
+//! Like [`crate::EmbeddingEngine`], inference runs on the blocking pool behind a
+//! `Mutex` (the ONNX models are not `Sync`), and the models download from
+//! HuggingFace on first use. Loaded only when image embeddings are enabled.
+
+use crate::{
+    EmbeddingError, Result, EMBEDDING_DIM, IMAGE_MODEL_NAME, IMAGE_MODEL_VERSION,
+    IMAGE_QUERY_MODEL_NAME,
+};
+use fastembed::{
+    EmbeddingModel, ImageEmbedding, ImageEmbeddingModel, ImageInitOptions, TextEmbedding,
+    TextInitOptions,
+};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use tracing::info;
+
+/// nomic-text retrieval prefix for queries (per the model card).
+const NOMIC_QUERY_PREFIX: &str = "search_query: ";
+
+/// Image-embedding batch size (image encoding is heavier than text).
+const IMAGE_BATCH_SIZE: usize = 8;
+
+/// In-process image + image-query embedding engine.
+pub struct ImageEmbeddingEngine {
+    image_model: Arc<Mutex<ImageEmbedding>>,
+    query_model: Arc<Mutex<TextEmbedding>>,
+}
+
+impl ImageEmbeddingEngine {
+    /// Load (and, on first run, download + cache) the nomic vision + text models.
+    pub async fn new() -> Result<Self> {
+        crate::engine::configure_ort_dylib_path();
+        let cache_dir: Option<PathBuf> =
+            std::env::var_os("SCREENSEARCH_MODEL_CACHE").map(PathBuf::from);
+
+        let (image_model, query_model) = tokio::task::spawn_blocking(move || {
+            let mut img_init = ImageInitOptions::new(ImageEmbeddingModel::NomicEmbedVisionV15)
+                .with_show_download_progress(true);
+            if let Some(dir) = &cache_dir {
+                img_init = img_init.with_cache_dir(dir.clone());
+            }
+            let image_model = ImageEmbedding::try_new(img_init)
+                .map_err(|error| EmbeddingError::ModelInitError(error.to_string()))?;
+
+            let mut txt_init = TextInitOptions::new(EmbeddingModel::NomicEmbedTextV15)
+                .with_show_download_progress(true);
+            if let Some(dir) = &cache_dir {
+                txt_init = txt_init.with_cache_dir(dir.clone());
+            }
+            let query_model = TextEmbedding::try_new(txt_init)
+                .map_err(|error| EmbeddingError::ModelInitError(error.to_string()))?;
+
+            Ok::<_, EmbeddingError>((
+                Arc::new(Mutex::new(image_model)),
+                Arc::new(Mutex::new(query_model)),
+            ))
+        })
+        .await
+        .map_err(|error| EmbeddingError::ModelInitError(error.to_string()))??;
+
+        info!(
+            image_model = IMAGE_MODEL_NAME,
+            query_model = IMAGE_QUERY_MODEL_NAME,
+            "Initialized in-process image embedding engine"
+        );
+
+        Ok(Self {
+            image_model,
+            query_model,
+        })
+    }
+
+    /// Embed screenshot files (by path) into 768-dim vectors.
+    pub async fn embed_images(&self, paths: Vec<String>) -> Result<Vec<Vec<f32>>> {
+        if paths.is_empty() {
+            return Ok(Vec::new());
+        }
+        let model = Arc::clone(&self.image_model);
+        let embeddings = tokio::task::spawn_blocking(move || {
+            let mut guard = model.lock().map_err(|_| {
+                EmbeddingError::InferenceError("image embedding model lock poisoned".into())
+            })?;
+            guard
+                .embed(paths, Some(IMAGE_BATCH_SIZE))
+                .map_err(|error| EmbeddingError::InferenceError(error.to_string()))
+        })
+        .await
+        .map_err(|error| EmbeddingError::InferenceError(error.to_string()))??;
+
+        for embedding in &embeddings {
+            if embedding.len() != EMBEDDING_DIM {
+                return Err(EmbeddingError::InferenceError(format!(
+                    "expected {EMBEDDING_DIM}-dim image embeddings, got {}",
+                    embedding.len()
+                )));
+            }
+        }
+        Ok(embeddings)
+    }
+
+    /// Embed a text query into the shared image/text space (with the nomic query
+    /// prefix), for searching the image index.
+    pub async fn embed_query(&self, text: &str) -> Result<Vec<f32>> {
+        let prompted = format!("{NOMIC_QUERY_PREFIX}{text}");
+        let model = Arc::clone(&self.query_model);
+        let mut embeddings = tokio::task::spawn_blocking(move || {
+            let mut guard = model.lock().map_err(|_| {
+                EmbeddingError::InferenceError("query embedding model lock poisoned".into())
+            })?;
+            guard
+                .embed(vec![prompted.as_str()], None)
+                .map_err(|error| EmbeddingError::InferenceError(error.to_string()))
+        })
+        .await
+        .map_err(|error| EmbeddingError::InferenceError(error.to_string()))??;
+
+        let embedding = embeddings
+            .pop()
+            .ok_or_else(|| EmbeddingError::InferenceError("model returned no embedding".into()))?;
+        if embedding.len() != EMBEDDING_DIM {
+            return Err(EmbeddingError::InferenceError(format!(
+                "expected {EMBEDDING_DIM}-dim query embeddings, got {}",
+                embedding.len()
+            )));
+        }
+        Ok(embedding)
+    }
+
+    pub fn provider(&self) -> &'static str {
+        "fastembed"
+    }
+
+    pub fn model(&self) -> &'static str {
+        IMAGE_MODEL_NAME
+    }
+
+    pub fn model_version(&self) -> &'static str {
+        IMAGE_MODEL_VERSION
+    }
+}

--- a/screensearch-embeddings/src/lib.rs
+++ b/screensearch-embeddings/src/lib.rs
@@ -33,12 +33,24 @@ use thiserror::Error;
 
 pub mod chunker;
 mod engine;
+mod image_engine;
 
 pub use chunker::TextChunker;
 pub use engine::{EmbeddingEngine, RerankScore};
+pub use image_engine::ImageEmbeddingEngine;
 
 /// Embedding dimension for EmbeddingGemma-300M (and the configured fallbacks).
 pub const EMBEDDING_DIM: usize = 768;
+
+/// Image-embedding model (screenshots) — aligned with [`IMAGE_QUERY_MODEL_NAME`]
+/// in a shared 768-dim space. Used by the optional visual-recall index.
+pub const IMAGE_MODEL_NAME: &str = "nomic-embed-vision-v1.5";
+
+/// Text encoder for image-search queries, aligned with [`IMAGE_MODEL_NAME`].
+pub const IMAGE_QUERY_MODEL_NAME: &str = "nomic-embed-text-v1.5";
+
+/// Model revision recorded in the image-vector contract.
+pub const IMAGE_MODEL_VERSION: &str = "1";
 
 /// Stable model identity recorded in the persisted-vector contract.
 ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,7 @@ fn default_embeddings_settings() -> EmbeddingsSettings {
     EmbeddingsSettings {
         enabled: false,
         batch_size: 50,
+        image_enabled: false,
     }
 }
 
@@ -167,6 +168,10 @@ struct LoggingSettings {
 struct EmbeddingsSettings {
     enabled: bool,
     batch_size: i64,
+    /// Enable the optional in-process image-embedding index (visual recall).
+    /// Off by default: loads extra models and adds per-frame image-embedding CPU.
+    #[serde(default)]
+    image_enabled: bool,
 }
 
 impl Default for AppConfig {
@@ -536,6 +541,24 @@ impl App {
         };
         if let Err(e) = api_server.start_embedding_worker(worker_config).await {
             warn!("Embedding worker did not start yet: {}", e);
+        }
+
+        // Optional image-embedding index (visual recall). The worker loop is
+        // always started but stays idle (no models loaded) until enabled via the
+        // `image_embeddings_enabled` flag, which config seeds and the API toggles.
+        api_server
+            .set_image_embeddings_enabled(self.config.embeddings.image_enabled)
+            .await?;
+        let image_worker_config =
+            screensearch_api::workers::image_embedding_worker::ImageEmbeddingWorkerConfig {
+                batch_size: self.config.embeddings.batch_size,
+                interval_secs: 60,
+            };
+        if let Err(e) = api_server
+            .start_image_embedding_worker(image_worker_config)
+            .await
+        {
+            warn!("Image embedding worker did not start yet: {}", e);
         }
 
         // Start vision analysis worker (shares AppState to drive the unified


### PR DESCRIPTION
## Summary

**Tier 2 of visual recall** (POC #74; Tier 1 #75 merged). Embeds screenshots **directly from pixels** with `nomic-embed-vision-v1.5` (768-dim) into a separate sqlite-vec index, and fuses image hits into `hybrid` search via Reciprocal Rank Fusion (queries encoded with the aligned `nomic-embed-text-v1.5`). This catches non-OCR visual content that even the Tier 1 vision *description* misses — charts, dense canvases, icon-only screens.

Runs fully **in-process** (fastembed/ONNX, CPU) — no Python, llama.cpp, or GPU. **Off by default** (`embeddings.image_enabled`; runtime toggle via `POST /api/embeddings/image/enable`). Enabling pulls fastembed's `image-models` codecs (longer build) and downloads the nomic models on first use.

## Design
- **Separate index** (`image_embeddings` + `image_embedding_vectors` vec0, migration 013): nomic-vision and EmbeddingGemma occupy *different* latent spaces, so a single KNN across both would be meaningless. The image index is one whole-frame vector per frame, queried only with the nomic-text encoder, and fused by **rank** (RRF k=60) — never a shared score threshold (cross-modal cosines are small in magnitude).
- **Opt-in & lazy**: the worker loop is always spawned but loads models / processes only while `image_embeddings_enabled` is set, so the API toggle works without a restart and the heavy models stay off by default. Search-path fusion is skipped unless the engine is already warm, so a first-run download never blocks a query.

## What's new
`ImageEmbeddingEngine` (embeddings crate) · migration 013 + image query/insert/status/ensure fns (db) · `image_embedding_worker` · `hybrid_search` image fusion · `state`/`server`/`main` wiring · `GET/POST /api/embeddings/image/{status,generate,enable}` · `embeddings.image_enabled` config.

## Verification (native Windows)
- `screensearch-db`: **3 lib + 25 integration + 1 doc** green, incl. new image-index tests (insert / KNN ranking / eligibility / replace / contract invalidation) and **hybrid_search image fusion** (a textless frame is retrieved only when an image-query vector is supplied):
```
test test_image_embedding_insert_search_and_eligibility ... ok
test test_hybrid_search_fuses_image_results ... ok
test result: ok. 25 passed; 0 failed
```
- **Real-engine proof** through the shipping `ImageEmbeddingEngine` (3 generated screenshots × 3 text queries):
```
              A_code    B_news   C_chart
      code    0.0907    0.0233    0.0389   -> A_code OK
      news    0.0458    0.0613    0.0399   -> B_news OK
     chart    0.0506    0.0315    0.0889   -> C_chart OK
RESULT: 3/3 queries retrieved the correct screenshot via ImageEmbeddingEngine.
```
The textless **bar chart** — no OCR, no recall path before this — was retrieved by "a bar chart graph". `cargo clippy -D warnings` clean; rustfmt clean; full workspace builds.

Docs: `architecture.md`, `api-reference.md`, `config.toml`, `CLAUDE.md`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)